### PR TITLE
fix: remove redirects de domínios www

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,19 +2,7 @@
   "redirects": [
     {
       "source": "/:path*",
-      "has": [{ "type": "host", "value": "www.andersondapper.com.br" }],
-      "destination": "https://andersondapper.com.br/:path*",
-      "permanent": true
-    },
-    {
-      "source": "/:path*",
       "has": [{ "type": "host", "value": "andersondapper.dev" }],
-      "destination": "https://andersondapper.com.br/:path*",
-      "permanent": true
-    },
-    {
-      "source": "/:path*",
-      "has": [{ "type": "host", "value": "www.andersondapper.dev" }],
       "destination": "https://andersondapper.com.br/:path*",
       "permanent": true
     }


### PR DESCRIPTION
## Resumo

- remove os redirects de www.andersondapper.com.br
- remove os redirects de www.andersondapper.dev
- preserva andersondapper.dev → andersondapper.com.br

## Motivo

Os aliases www não serão mais usados. A remoção no código evita manter regras para hosts que serão retirados do DNS e da configuração de domínios.

## Validação

- [x] JSON válido
- [x] pnpm install --frozen-lockfile
- [x] pnpm lint
- [x] pnpm build
- [x] pnpm exec tsc --noEmit --incremental false
- [x] snapshot isolado do commit

O projeto não possui script de testes automatizados configurado.

## Ação externa restante

Remover os aliases www no Cloudflare e na Vercel. Essas configurações não são alteradas por este PR.