### PR TITLE
feat: adiciona página sobre

### DIFF
--- a/src/app/about/content.ts
+++ b/src/app/about/content.ts
@@ -1,0 +1,61 @@
+import { FaCheckCircle, FaRocket, FaSearch, FaServer } from 'react-icons/fa'
+import { SiDelphi, SiNextdotjs } from 'react-icons/si'
+
+export const pageDescription =
+  'Conheça a trajetória de Anderson Dapper: mais de 20 anos modernizando sistemas críticos e construindo APIs, produtos web e infraestrutura.'
+
+export const journey = [
+  {
+    eyebrow: 'Fundação',
+    title: 'Sistemas Delphi e regras críticas',
+    description:
+      'Comecei no desenvolvimento desktop e construí uma base sólida em arquitetura, dados e operação. Foram anos entendendo sistemas que sustentam rotinas reais e não podem simplesmente parar.',
+    icon: SiDelphi,
+    iconClassName: 'text-red-500',
+    gradient: 'from-red-500 to-orange-500',
+  },
+  {
+    eyebrow: 'Evolução',
+    title: 'Web, APIs e novas experiências',
+    description:
+      'A partir de 2022, ampliei essa experiência para Node.js, Next.js, NestJS e Golang. A mudança não apagou o legado: trouxe ferramentas novas para evoluí-lo com segurança.',
+    icon: SiNextdotjs,
+    iconClassName: 'text-slate-900 dark:text-white',
+    gradient: 'from-cyan-500 to-blue-600',
+  },
+  {
+    eyebrow: 'Hoje',
+    title: 'Engenharia de ponta a ponta',
+    description:
+      'Atuo da modelagem de dados à interface, passando por integração, infraestrutura, entrega e observabilidade. O trabalho só termina quando o software está utilizável e verificável em produção.',
+    icon: FaRocket,
+    iconClassName: 'text-purple-500',
+    gradient: 'from-purple-500 to-violet-600',
+  },
+]
+
+export const workingPrinciples = [
+  {
+    title: 'Entender antes de substituir',
+    description:
+      'Mapeio regras, dependências e riscos antes de escolher a solução. Em sistemas maduros, o comportamento existente é parte do contrato.',
+    icon: FaSearch,
+    gradient: 'from-cyan-500 to-blue-600',
+  },
+  {
+    title: 'Evoluir em etapas verificáveis',
+    description:
+      'Prefiro entregas menores, paridade explícita e validação contínua. Isso reduz risco e deixa decisões técnicas fáceis de revisar.',
+    icon: FaCheckCircle,
+    gradient: 'from-emerald-500 to-teal-600',
+  },
+  {
+    title: 'Levar a entrega até produção',
+    description:
+      'Build verde é só uma etapa. Deploy, saúde, logs e experiência real também fazem parte da responsabilidade de quem constrói.',
+    icon: FaServer,
+    gradient: 'from-purple-500 to-violet-600',
+  },
+]
+
+export const sectors = ['Varejo', 'Fiscal e contábil', 'Bancário', 'Educacional']

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,275 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import {
+  FaArrowLeft,
+  FaArrowRight,
+  FaCar,
+  FaCheckCircle,
+  FaGamepad,
+} from 'react-icons/fa'
+import SectionHeading from '../../components/SectionHeading'
+import ThemeToggle from '../../components/ThemeToggle'
+import { journey, pageDescription, sectors, workingPrinciples } from './content'
+
+export const metadata: Metadata = {
+  title: 'Sobre',
+  description: pageDescription,
+  alternates: {
+    canonical: '/about',
+  },
+  openGraph: {
+    type: 'website',
+    url: '/about',
+    title: 'Sobre Anderson Dapper | Do legado à plataforma',
+    description: pageDescription,
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Anderson Dapper - Software legado, APIs e Web',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Sobre Anderson Dapper | Do legado à plataforma',
+    description: pageDescription,
+    images: ['/og-image.png'],
+  },
+}
+
+export default function AboutPage() {
+  return (
+    <div>
+      <nav
+        aria-label="Navegação da página"
+        className="mb-8 flex items-center justify-between gap-4 animate-fade-in"
+      >
+        <Link
+          href="/"
+          className="group inline-flex min-h-11 items-center gap-2 rounded-lg px-2 text-sm font-medium text-slate-500 transition-colors hover:text-cyan-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 dark:text-slate-400 dark:hover:text-cyan-300"
+        >
+          <FaArrowLeft
+            aria-hidden="true"
+            className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-1"
+          />
+          Voltar para a página inicial
+        </Link>
+        <ThemeToggle />
+      </nav>
+
+      <header className="relative mb-16 overflow-hidden rounded-3xl border border-slate-200/70 bg-white/55 px-5 py-10 dark:border-slate-700/70 dark:bg-slate-900/45 sm:px-8 sm:py-14 lg:px-12">
+        <div className="relative z-10 max-w-3xl animate-fade-in-up">
+          <p className="mb-4 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-cyan-700 dark:text-cyan-300">
+            Sobre mim · mais de 20 anos construindo software
+          </p>
+          <h1 className="text-4xl font-black leading-tight tracking-tight text-slate-950 dark:text-white sm:text-5xl lg:text-6xl">
+            Do legado à plataforma, sem perder o que faz o negócio funcionar.
+          </h1>
+          <p className="mt-6 max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-300 sm:text-lg">
+            Minha especialidade é conectar décadas de regras de negócio a arquiteturas,
+            APIs e produtos atuais — com evolução gradual, responsabilidade operacional
+            e evidência de que cada etapa funciona.
+          </p>
+
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Link
+              href="/#projetos"
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-500 to-blue-600 px-6 py-3 font-semibold text-white shadow-lg shadow-cyan-500/20 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
+            >
+              Ver cases
+              <FaArrowRight aria-hidden="true" className="h-4 w-4" />
+            </Link>
+            <Link
+              href="/#contato"
+              className="inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-300/80 bg-white/70 px-6 py-3 font-semibold text-slate-800 transition-all hover:-translate-y-0.5 hover:border-purple-400 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 dark:hover:border-purple-400"
+            >
+              Entrar em contato
+            </Link>
+          </div>
+        </div>
+
+        <div
+          aria-hidden="true"
+          className="absolute -right-16 -top-20 h-56 w-56 rounded-full bg-gradient-to-br from-cyan-400/20 to-blue-500/5 blur-3xl"
+        />
+        <div
+          aria-hidden="true"
+          className="absolute -bottom-24 right-1/4 h-52 w-52 rounded-full bg-gradient-to-br from-purple-500/15 to-transparent blur-3xl"
+        />
+      </header>
+
+      <section className="mb-16 sm:mb-20" aria-labelledby="journey-title">
+        <SectionHeading
+          id="journey-title"
+          eyebrow="Delphi → Web → Plataforma"
+          title="Uma trajetória de evolução"
+          subtitle="Ferramentas mudam. Responsabilidade técnica permanece."
+          className="mb-8"
+        />
+
+        <ol className="grid gap-4 lg:grid-cols-3">
+          {journey.map((stage, index) => {
+            const Icon = stage.icon
+
+            return (
+              <li
+                key={stage.title}
+                className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/70 bg-white/65 p-5 shadow-sm transition-all hover:-translate-y-1 hover:shadow-xl dark:border-slate-700/70 dark:bg-slate-800/65 sm:p-6"
+              >
+                <div className="mb-5 flex items-center justify-between gap-4">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-slate-100 shadow-sm dark:bg-slate-900/80">
+                    <Icon aria-hidden="true" className={`h-5 w-5 ${stage.iconClassName}`} />
+                  </div>
+                  <span className="font-mono text-xs font-semibold text-slate-400 dark:text-slate-500">
+                    0{index + 1}
+                  </span>
+                </div>
+                <p className="mb-2 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-cyan-700 dark:text-cyan-300">
+                  {stage.eyebrow}
+                </p>
+                <h3 className="mb-3 text-xl font-bold text-slate-900 dark:text-white">
+                  {stage.title}
+                </h3>
+                <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                  {stage.description}
+                </p>
+                <div
+                  aria-hidden="true"
+                  className={`absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r ${stage.gradient}`}
+                />
+              </li>
+            )
+          })}
+        </ol>
+
+        <div className="mt-5 rounded-2xl border border-cyan-200/60 bg-gradient-to-r from-cyan-50/80 to-purple-50/80 p-5 dark:border-cyan-900/60 dark:from-cyan-950/30 dark:to-purple-950/30 sm:p-6">
+          <p className="mb-4 text-sm font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+            Experiência com sistemas críticos
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {sectors.map((sector) => (
+              <span
+                key={sector}
+                className="rounded-full border border-slate-200/80 bg-white/80 px-3 py-1.5 text-sm font-medium text-slate-700 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200"
+              >
+                {sector}
+              </span>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mb-16 sm:mb-20" aria-labelledby="work-title">
+        <SectionHeading
+          id="work-title"
+          eyebrow="Método"
+          title="Como eu trabalho"
+          subtitle="Decisões técnicas ligadas ao risco e ao resultado."
+          className="mb-8"
+        />
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          {workingPrinciples.map((principle) => {
+            const Icon = principle.icon
+
+            return (
+              <article
+                key={principle.title}
+                className="rounded-2xl border border-slate-200/70 bg-white/60 p-5 dark:border-slate-700/70 dark:bg-slate-800/60 sm:p-6"
+              >
+                <div
+                  className={`mb-5 flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br ${principle.gradient} text-white shadow-md`}
+                >
+                  <Icon aria-hidden="true" className="h-4 w-4" />
+                </div>
+                <h3 className="mb-3 text-lg font-bold text-slate-900 dark:text-white">
+                  {principle.title}
+                </h3>
+                <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                  {principle.description}
+                </p>
+              </article>
+            )
+          })}
+        </div>
+      </section>
+
+      <section className="mb-16 grid gap-5 lg:grid-cols-[1.35fr_0.65fr]" aria-labelledby="principles-title">
+        <div className="rounded-2xl border border-slate-200/70 bg-white/60 p-5 dark:border-slate-700/70 dark:bg-slate-800/60 sm:p-7">
+          <SectionHeading
+            id="principles-title"
+            eyebrow="Princípios"
+            title="O que orienta minhas decisões"
+            className="mb-7"
+          />
+          <ul className="space-y-4">
+            {[
+              'Regra de negócio antes de modismo tecnológico.',
+              'Evidência antes de suposição — no código, no deploy e na operação.',
+              'Soluções simples o bastante para serem mantidas e profundas o bastante para durar.',
+            ].map((principle) => (
+              <li key={principle} className="flex gap-3 text-sm leading-relaxed text-slate-700 dark:text-slate-300 sm:text-base">
+                <FaCheckCircle
+                  aria-hidden="true"
+                  className="mt-1 h-4 w-4 shrink-0 text-emerald-500"
+                />
+                {principle}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <aside className="rounded-2xl border border-purple-200/60 bg-gradient-to-br from-purple-50/80 to-cyan-50/70 p-5 dark:border-purple-900/60 dark:from-purple-950/30 dark:to-cyan-950/20 sm:p-7">
+          <p className="mb-2 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-purple-700 dark:text-purple-300">
+            Fora do código
+          </p>
+          <h3 className="mb-4 text-xl font-bold text-slate-900 dark:text-white">
+            Curiosidade também precisa de espaço.
+          </h3>
+          <p className="mb-6 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+            Games ajudam a desacelerar e treinar decisões. Automobilismo mantém perto a
+            combinação de engenharia, precisão e performance que também me atrai em
+            software.
+          </p>
+          <div className="flex gap-3">
+            <span className="inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 dark:bg-slate-900/70 dark:text-slate-200">
+              <FaGamepad aria-hidden="true" className="text-purple-500" />
+              Games
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 dark:bg-slate-900/70 dark:text-slate-200">
+              <FaCar aria-hidden="true" className="text-orange-500" />
+              Automobilismo
+            </span>
+          </div>
+        </aside>
+      </section>
+
+      <section
+        aria-labelledby="about-contact-title"
+        className="relative overflow-hidden rounded-2xl border border-cyan-200/60 bg-gradient-to-br from-cyan-50 via-blue-50 to-purple-50 p-7 text-center dark:border-cyan-900/60 dark:from-cyan-950/35 dark:via-blue-950/30 dark:to-purple-950/35 sm:p-10"
+      >
+        <div className="relative z-10 mx-auto max-w-2xl">
+          <h2
+            id="about-contact-title"
+            className="text-2xl font-bold text-slate-950 dark:text-white sm:text-3xl"
+          >
+            Tem um sistema importante para evoluir?
+          </h2>
+          <p className="mx-auto mt-3 max-w-xl text-base leading-relaxed text-slate-600 dark:text-slate-300">
+            Podemos conversar sobre modernização, APIs, arquitetura ou uma entrega que
+            precisa chegar à produção com segurança.
+          </p>
+          <Link
+            href="/#contato"
+            className="mt-7 inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-500 to-blue-600 px-7 py-3 font-semibold text-white shadow-lg shadow-cyan-500/20 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
+          >
+            Vamos conversar
+            <FaArrowRight aria-hidden="true" className="h-4 w-4" />
+          </Link>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import EasterEggWrapper from '../components/EasterEggWrapper'
 import Stack from '../components/Stack'
 import Contact from '../components/Contact'
 import Footer from '../components/Footer'
+import SectionHeading from '../components/SectionHeading'
 import { FaFileInvoice, FaLayerGroup, FaRocket } from 'react-icons/fa'
 
 const caseStudies = [
@@ -42,20 +43,12 @@ const caseStudies = [
 function FeaturedWork() {
   return (
     <section id="projetos" className="mb-20 scroll-mt-6" aria-labelledby="projetos-title">
-      <div className="mb-8 flex items-center gap-4 animate-fade-in sm:mb-10">
-        <div className="relative">
-          <div className="h-12 w-2 rounded-full bg-gradient-to-b from-cyan-500 via-purple-500 to-blue-500" />
-          <div className="absolute inset-0 h-12 w-2 rounded-full bg-gradient-to-b from-cyan-500 via-purple-500 to-blue-500 opacity-50 blur-sm" />
-        </div>
-        <div>
-          <p className="mb-1 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-cyan-700 dark:text-cyan-300">
-            Problema → engenharia → resultado
-          </p>
-          <h2 id="projetos-title" className="text-3xl font-bold text-slate-900 dark:text-slate-100 sm:text-4xl">
-            Trabalho em contexto real
-          </h2>
-        </div>
-      </div>
+      <SectionHeading
+        id="projetos-title"
+        eyebrow="Problema → engenharia → resultado"
+        title="Trabalho em contexto real"
+        className="mb-8 sm:mb-10"
+      />
 
       <p className="mb-7 max-w-3xl text-base leading-relaxed text-slate-600 dark:text-slate-400 sm:text-lg">
         Alguns projetos são privados. Estes recortes mostram problema, atuação e impacto

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,12 +1,20 @@
 import { MetadataRoute } from 'next'
 
 export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date()
+
   return [
     {
       url: 'https://andersondapper.com.br',
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'monthly',
       priority: 1,
+    },
+    {
+      url: 'https://andersondapper.com.br/about',
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
     },
   ]
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+import { FaArrowRight } from 'react-icons/fa'
 import SectionHeading from './SectionHeading'
 
 interface TimelineItemProps {
@@ -52,7 +54,7 @@ function Tech({ children }: { children: React.ReactNode }) {
 
 export default function About() {
   return (
-    <section className="mb-16 sm:mb-20" aria-labelledby="about-title">
+    <section id="sobre" className="mb-16 scroll-mt-6 sm:mb-20" aria-labelledby="about-title">
       <SectionHeading
         id="about-title"
         title="Sobre mim"
@@ -96,6 +98,19 @@ export default function About() {
         >
           <Highlight>Foco em resultados</Highlight> e comprometimento com a qualidade. Experiência tanto em manutenção de sistemas legados quanto em arquitetura de novas soluções. Interesse genuíno por tecnologia, complementado por hobbies em games e automobilismo.
         </TimelineItem>
+      </div>
+
+      <div className="flex justify-start sm:ml-[4.5rem]">
+        <Link
+          href="/about"
+          className="group inline-flex min-h-11 items-center gap-2 rounded-lg px-2 font-semibold text-cyan-700 transition-colors hover:text-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 dark:text-cyan-300 dark:hover:text-blue-300"
+        >
+          Conheça minha trajetória completa
+          <FaArrowRight
+            aria-hidden="true"
+            className="h-4 w-4 transition-transform group-hover:translate-x-1"
+          />
+        </Link>
       </div>
     </section>
   )

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,3 +1,5 @@
+import SectionHeading from './SectionHeading'
+
 interface TimelineItemProps {
   icon: string
   color: string
@@ -50,21 +52,13 @@ function Tech({ children }: { children: React.ReactNode }) {
 
 export default function About() {
   return (
-    <section className="mb-16 sm:mb-20">
-      <div className="flex items-center gap-4 mb-7 animate-fade-in sm:mb-10">
-        <div className="relative">
-          <div className="w-2 h-12 bg-gradient-to-b from-cyan-500 via-purple-500 to-blue-500 rounded-full" />
-          <div className="absolute inset-0 w-2 h-12 bg-gradient-to-b from-cyan-500 via-purple-500 to-blue-500 rounded-full blur-sm opacity-50" />
-        </div>
-        <div>
-          <h2 className="text-3xl sm:text-4xl font-bold text-slate-900 dark:text-slate-100">
-            Sobre mim
-          </h2>
-          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-            +20 anos construindo soluções
-          </p>
-        </div>
-      </div>
+    <section className="mb-16 sm:mb-20" aria-labelledby="about-title">
+      <SectionHeading
+        id="about-title"
+        title="Sobre mim"
+        subtitle="+20 anos construindo soluções"
+        className="mb-7 sm:mb-10"
+      />
 
       <div className="relative sm:ml-6">
         <TimelineItem 

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import SectionHeading from './SectionHeading'
+
 interface SocialLinkProps {
   name: string
   url: string
@@ -103,22 +105,12 @@ export default function Contact() {
   ]
 
   return (
-    <section className="mb-20">
-      {/* Section header */}
-      <div className="flex items-center gap-4 mb-10 animate-fade-in">
-        <div className="relative">
-          <div className="w-2 h-12 bg-gradient-to-b from-cyan-500 via-purple-500 to-blue-500 rounded-full" />
-          <div className="absolute inset-0 w-2 h-12 bg-gradient-to-b from-cyan-500 via-purple-500 to-blue-500 rounded-full blur-sm opacity-50" />
-        </div>
-        <div>
-          <h2 className="text-3xl sm:text-4xl font-bold text-slate-900 dark:text-slate-100">
-            Vamos conversar?
-          </h2>
-          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-            Sempre aberto a novas oportunidades
-          </p>
-        </div>
-      </div>
+    <section className="mb-20" aria-labelledby="contact-title">
+      <SectionHeading
+        id="contact-title"
+        title="Vamos conversar?"
+        subtitle="Sempre aberto a novas oportunidades"
+      />
 
       {/* Intro text */}
       <div className="mb-8 p-6 rounded-2xl bg-gradient-to-br from-cyan-50 to-purple-50 dark:from-cyan-950/30 dark:to-purple-950/30 border border-cyan-200/50 dark:border-cyan-800/30 animate-fade-in-up delay-100">

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -105,7 +105,7 @@ export default function Contact() {
   ]
 
   return (
-    <section className="mb-20" aria-labelledby="contact-title">
+    <section id="contato" className="mb-20 scroll-mt-6" aria-labelledby="contact-title">
       <SectionHeading
         id="contact-title"
         title="Vamos conversar?"

--- a/src/components/SectionHeading.tsx
+++ b/src/components/SectionHeading.tsx
@@ -1,0 +1,43 @@
+interface SectionHeadingProps {
+  title: string
+  id?: string
+  eyebrow?: string
+  subtitle?: string
+  className?: string
+}
+
+export default function SectionHeading({
+  title,
+  id,
+  eyebrow,
+  subtitle,
+  className = 'mb-10',
+}: SectionHeadingProps) {
+  return (
+    <div className={`${className} flex items-center gap-4 animate-fade-in`}>
+      <div aria-hidden="true" className="relative">
+        <div className="h-12 w-2 rounded-full bg-gradient-to-b from-cyan-500 via-purple-500 to-blue-500" />
+        <div className="absolute inset-0 h-12 w-2 rounded-full bg-gradient-to-b from-cyan-500 via-purple-500 to-blue-500 opacity-50 blur-sm" />
+      </div>
+
+      <div>
+        {eyebrow && (
+          <p className="mb-1 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-cyan-700 dark:text-cyan-300">
+            {eyebrow}
+          </p>
+        )}
+        <h2
+          id={id}
+          className="text-3xl font-bold text-slate-900 dark:text-slate-100 sm:text-4xl"
+        >
+          {title}
+        </h2>
+        {subtitle && (
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            {subtitle}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -23,6 +23,7 @@ import {
   SiDelphi
 } from 'react-icons/si'
 import { FaAws, FaServer, FaCloud } from 'react-icons/fa'
+import SectionHeading from './SectionHeading'
 
 interface StackItem {
   name: string
@@ -60,22 +61,12 @@ export default function Stack() {
   ]
 
   return (
-    <section className="mb-20">
-      {/* Section header */}
-      <div className="flex items-center gap-4 mb-10 animate-fade-in">
-        <div className="relative">
-          <div className="w-2 h-12 bg-gradient-to-b from-cyan-500 via-purple-500 to-blue-500 rounded-full" />
-          <div className="absolute inset-0 w-2 h-12 bg-gradient-to-b from-cyan-500 via-purple-500 to-blue-500 rounded-full blur-sm opacity-50" />
-        </div>
-        <div>
-          <h2 className="text-3xl sm:text-4xl font-bold text-slate-900 dark:text-slate-100">
-            Stack & Ferramentas
-          </h2>
-          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-            Tecnologias que uso no dia a dia
-          </p>
-        </div>
-      </div>
+    <section className="mb-20" aria-labelledby="stack-title">
+      <SectionHeading
+        id="stack-title"
+        title="Stack & Ferramentas"
+        subtitle="Tecnologias que uso no dia a dia"
+      />
 
       {/* Stack Grid */}
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">


### PR DESCRIPTION
## Resumo

- extrai o cabeçalho compartilhado das seções da home
- publica a rota /about com trajetória, método, princípios e CTA
- adiciona o acesso à trajetória completa na home
- conecta os CTAs à seção de contato
- inclui metadata social, canonical e /about no sitemap

## Validação

- [x] pnpm install --frozen-lockfile
- [x] pnpm lint
- [x] pnpm build
- [x] pnpm exec tsc --noEmit --incremental false
- [x] validação isolada do snapshot exato
- [x] desktop e viewport móvel sem overflow horizontal
- [x] navegação home → about → contato
- [x] alternância de tema e console sem erros ou avisos
- [ ] preview da Vercel

O projeto não possui script de testes automatizados configurado.