### PR TITLE
feat: adiciona cases detalhados ao portfólio

### DIFF
--- a/src/app/cases/[slug]/CaseStudyHero.tsx
+++ b/src/app/cases/[slug]/CaseStudyHero.tsx
@@ -1,0 +1,125 @@
+import type { IconType } from 'react-icons'
+import { FaFileInvoice, FaLayerGroup, FaRocket } from 'react-icons/fa'
+import type {
+  CaseStudyIcon,
+  PublishedCaseStudy,
+} from '../../../data/case-studies'
+
+interface CaseStudyVisual {
+  Icon: IconType
+  badge: string
+  summaryCard: string
+  summaryLabel: string
+  iconBackground: string
+  glow: string
+  noteBorder: string
+  constraintIcon: string
+}
+
+export const caseStudyVisuals: Record<CaseStudyIcon, CaseStudyVisual> = {
+  layers: {
+    Icon: FaLayerGroup,
+    badge:
+      'bg-orange-100 text-orange-700 dark:bg-orange-950/50 dark:text-orange-300',
+    summaryCard:
+      'border-orange-200/70 from-orange-50/90 to-red-50/70 dark:border-orange-900/60 dark:from-orange-950/30 dark:to-red-950/20',
+    summaryLabel: 'text-orange-700 dark:text-orange-300',
+    iconBackground: 'from-red-500 to-orange-500',
+    glow: 'from-orange-400/15 to-red-500/5',
+    noteBorder: 'border-orange-400',
+    constraintIcon: 'text-orange-500',
+  },
+  invoice: {
+    Icon: FaFileInvoice,
+    badge:
+      'bg-cyan-100 text-cyan-800 dark:bg-cyan-950/50 dark:text-cyan-300',
+    summaryCard:
+      'border-cyan-200/70 from-cyan-50/90 to-blue-50/70 dark:border-cyan-900/60 dark:from-cyan-950/30 dark:to-blue-950/20',
+    summaryLabel: 'text-cyan-800 dark:text-cyan-300',
+    iconBackground: 'from-cyan-500 to-blue-600',
+    glow: 'from-cyan-400/15 to-blue-500/5',
+    noteBorder: 'border-cyan-400',
+    constraintIcon: 'text-cyan-500',
+  },
+  rocket: {
+    Icon: FaRocket,
+    badge:
+      'bg-purple-100 text-purple-800 dark:bg-purple-950/50 dark:text-purple-300',
+    summaryCard:
+      'border-purple-200/70 from-purple-50/90 to-violet-50/70 dark:border-purple-900/60 dark:from-purple-950/30 dark:to-violet-950/20',
+    summaryLabel: 'text-purple-800 dark:text-purple-300',
+    iconBackground: 'from-purple-500 to-violet-600',
+    glow: 'from-purple-400/15 to-violet-500/5',
+    noteBorder: 'border-purple-400',
+    constraintIcon: 'text-purple-500',
+  },
+}
+
+interface CaseStudyHeroProps {
+  caseStudy: PublishedCaseStudy
+}
+
+export default function CaseStudyHero({ caseStudy }: CaseStudyHeroProps) {
+  const { details } = caseStudy
+  const visual = caseStudyVisuals[caseStudy.icon]
+  const Icon = visual.Icon
+
+  return (
+    <header className="relative mb-16 overflow-hidden rounded-3xl border border-slate-200/70 bg-white/55 px-5 py-8 dark:border-slate-700/70 dark:bg-slate-900/45 sm:px-8 sm:py-12 lg:px-12">
+      <div className="relative z-10 grid gap-8 lg:grid-cols-[1fr_0.42fr] lg:items-end">
+        <div className="animate-fade-in-up">
+          <div className="mb-5 flex flex-wrap items-center gap-3">
+            <span
+              className={`rounded-full px-3 py-1 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.16em] ${visual.badge}`}
+            >
+              Case anonimizado
+            </span>
+            <span className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+              {caseStudy.context}
+            </span>
+          </div>
+          <h1 className="text-4xl font-black leading-tight tracking-tight text-slate-950 dark:text-white sm:text-5xl lg:text-6xl">
+            {caseStudy.title}
+          </h1>
+          <p className="mt-6 max-w-3xl text-base leading-relaxed text-slate-600 dark:text-slate-300 sm:text-lg">
+            {details.intro}
+          </p>
+
+          <div className="mt-7 flex flex-wrap gap-2">
+            {details.tags.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200/80 bg-white/75 px-3 py-1.5 text-xs font-medium text-slate-700 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <aside
+          className={`rounded-2xl border bg-gradient-to-br p-5 sm:p-6 ${visual.summaryCard}`}
+        >
+          <div
+            className={`mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-lg ${visual.iconBackground}`}
+          >
+            <Icon aria-hidden="true" className="h-5 w-5" />
+          </div>
+          <p
+            className={`mb-2 text-xs font-bold uppercase tracking-[0.14em] ${visual.summaryLabel}`}
+          >
+            Resultado em síntese
+          </p>
+          <p className="text-sm font-medium leading-relaxed text-slate-800 dark:text-slate-200">
+            {caseStudy.result}
+          </p>
+        </aside>
+      </div>
+
+      <div
+        aria-hidden="true"
+        className={`absolute -right-16 -top-20 h-56 w-56 rounded-full bg-gradient-to-br blur-3xl ${visual.glow}`}
+      />
+    </header>
+  )
+}

--- a/src/app/cases/[slug]/page.tsx
+++ b/src/app/cases/[slug]/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { FaArrowLeft, FaArrowRight, FaCheckCircle, FaLayerGroup } from 'react-icons/fa'
+import { FaArrowLeft, FaArrowRight, FaCheckCircle } from 'react-icons/fa'
 import SectionHeading from '../../../components/SectionHeading'
 import ThemeToggle from '../../../components/ThemeToggle'
 import { getPublishedCaseStudy, publishedCaseStudies } from '../../../data/case-studies'
+import CaseStudyHero, { caseStudyVisuals } from './CaseStudyHero'
 
 interface CaseStudyPageProps {
   params: Promise<{ slug: string }>
@@ -56,6 +57,7 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
   }
 
   const { details } = caseStudy
+  const visual = caseStudyVisuals[caseStudy.icon]
 
   return (
     <div>
@@ -73,61 +75,14 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
         <ThemeToggle />
       </nav>
 
-      <header className="relative mb-16 overflow-hidden rounded-3xl border border-slate-200/70 bg-white/55 px-5 py-8 dark:border-slate-700/70 dark:bg-slate-900/45 sm:px-8 sm:py-12 lg:px-12">
-        <div className="relative z-10 grid gap-8 lg:grid-cols-[1fr_0.42fr] lg:items-end">
-          <div className="animate-fade-in-up">
-            <div className="mb-5 flex flex-wrap items-center gap-3">
-              <span className="rounded-full bg-orange-100 px-3 py-1 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-orange-700 dark:bg-orange-950/50 dark:text-orange-300">
-                Case anonimizado
-              </span>
-              <span className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                {caseStudy.context}
-              </span>
-            </div>
-            <h1 className="text-4xl font-black leading-tight tracking-tight text-slate-950 dark:text-white sm:text-5xl lg:text-6xl">
-              {caseStudy.title}
-            </h1>
-            <p className="mt-6 max-w-3xl text-base leading-relaxed text-slate-600 dark:text-slate-300 sm:text-lg">
-              {details.intro}
-            </p>
-
-            <div className="mt-7 flex flex-wrap gap-2">
-              {details.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded-full border border-slate-200/80 bg-white/75 px-3 py-1.5 text-xs font-medium text-slate-700 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          </div>
-
-          <aside className="rounded-2xl border border-orange-200/70 bg-gradient-to-br from-orange-50/90 to-red-50/70 p-5 dark:border-orange-900/60 dark:from-orange-950/30 dark:to-red-950/20 sm:p-6">
-            <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-red-500 to-orange-500 text-white shadow-lg">
-              <FaLayerGroup aria-hidden="true" className="h-5 w-5" />
-            </div>
-            <p className="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-orange-700 dark:text-orange-300">
-              Resultado em síntese
-            </p>
-            <p className="text-sm font-medium leading-relaxed text-slate-800 dark:text-slate-200">
-              {caseStudy.result}
-            </p>
-          </aside>
-        </div>
-
-        <div
-          aria-hidden="true"
-          className="absolute -right-16 -top-20 h-56 w-56 rounded-full bg-gradient-to-br from-orange-400/15 to-red-500/5 blur-3xl"
-        />
-      </header>
+      <CaseStudyHero caseStudy={caseStudy} />
 
       <section className="mb-16 sm:mb-20" aria-labelledby="challenge-title">
         <SectionHeading
           id="challenge-title"
           eyebrow="Contexto"
           title="O desafio"
-          subtitle="Modernizar sem transformar a operação em laboratório."
+          subtitle={details.sectionSubtitles.challenge}
           className="mb-8"
         />
 
@@ -136,7 +91,7 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
             <p className="text-base leading-relaxed text-slate-700 dark:text-slate-300 sm:text-lg">
               {details.challenge}
             </p>
-            <p className="mt-6 border-l-2 border-orange-400 pl-4 text-sm leading-relaxed text-slate-500 dark:text-slate-400">
+            <p className={`mt-6 border-l-2 pl-4 text-sm leading-relaxed text-slate-500 dark:text-slate-400 ${visual.noteBorder}`}>
               {details.confidentialityNote}
             </p>
           </div>
@@ -149,7 +104,7 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
               >
                 <FaCheckCircle
                   aria-hidden="true"
-                  className="mt-0.5 h-4 w-4 shrink-0 text-orange-500"
+                  className={`mt-0.5 h-4 w-4 shrink-0 ${visual.constraintIcon}`}
                 />
                 {constraint}
               </li>
@@ -163,7 +118,7 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
           id="role-title"
           eyebrow="Responsabilidade"
           title="Minha atuação"
-          subtitle="Do entendimento do legado à comprovação em produção."
+          subtitle={details.sectionSubtitles.responsibilities}
           className="mb-8"
         />
 
@@ -189,7 +144,7 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
           id="approach-title"
           eyebrow="Estratégia"
           title="A abordagem"
-          subtitle="Uma sequência repetível em vez de uma grande virada."
+          subtitle={details.sectionSubtitles.approach}
           className="mb-8"
         />
 
@@ -279,17 +234,16 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
           id="case-contact-title"
           className="text-2xl font-bold text-slate-950 dark:text-white sm:text-3xl"
         >
-          Precisa evoluir um sistema sem apostar tudo em uma reescrita?
+          {details.callToAction.title}
         </h2>
         <p className="mx-auto mt-3 max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-300">
-          Podemos conversar sobre um caminho incremental, com regras explícitas,
-          entregas verificáveis e risco operacional controlado.
+          {details.callToAction.description}
         </p>
         <Link
           href="/#contato"
           className="mt-7 inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-500 to-blue-600 px-7 py-3 font-semibold text-white shadow-lg shadow-cyan-500/20 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
         >
-          Conversar sobre modernização
+          {details.callToAction.label}
           <FaArrowRight aria-hidden="true" className="h-4 w-4" />
         </Link>
       </section>

--- a/src/app/cases/[slug]/page.tsx
+++ b/src/app/cases/[slug]/page.tsx
@@ -1,0 +1,298 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { FaArrowLeft, FaArrowRight, FaCheckCircle, FaLayerGroup } from 'react-icons/fa'
+import SectionHeading from '../../../components/SectionHeading'
+import ThemeToggle from '../../../components/ThemeToggle'
+import { getPublishedCaseStudy, publishedCaseStudies } from '../../../data/case-studies'
+
+interface CaseStudyPageProps {
+  params: Promise<{ slug: string }>
+}
+
+export function generateStaticParams() {
+  return publishedCaseStudies.map(({ slug }) => ({ slug }))
+}
+
+export async function generateMetadata({ params }: CaseStudyPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const caseStudy = getPublishedCaseStudy(slug)
+
+  if (!caseStudy) {
+    return {}
+  }
+
+  const canonical = `/cases/${caseStudy.slug}`
+  const socialTitle = `${caseStudy.title} | Case de engenharia`
+
+  return {
+    title: caseStudy.title,
+    description: caseStudy.details.seoDescription,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      type: 'article',
+      url: canonical,
+      title: socialTitle,
+      description: caseStudy.details.seoDescription,
+      images: [],
+    },
+    twitter: {
+      card: 'summary',
+      title: socialTitle,
+      description: caseStudy.details.seoDescription,
+      images: [],
+    },
+  }
+}
+
+export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
+  const { slug } = await params
+  const caseStudy = getPublishedCaseStudy(slug)
+
+  if (!caseStudy) {
+    notFound()
+  }
+
+  const { details } = caseStudy
+
+  return (
+    <div>
+      <nav aria-label="Navegação do case" className="mb-8 flex items-center justify-between gap-4 animate-fade-in">
+        <Link
+          href="/#projetos"
+          className="group inline-flex min-h-11 items-center gap-2 rounded-lg px-2 text-sm font-medium text-slate-500 transition-colors hover:text-cyan-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 dark:text-slate-400 dark:hover:text-cyan-300"
+        >
+          <FaArrowLeft
+            aria-hidden="true"
+            className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-1"
+          />
+          Voltar aos cases
+        </Link>
+        <ThemeToggle />
+      </nav>
+
+      <header className="relative mb-16 overflow-hidden rounded-3xl border border-slate-200/70 bg-white/55 px-5 py-8 dark:border-slate-700/70 dark:bg-slate-900/45 sm:px-8 sm:py-12 lg:px-12">
+        <div className="relative z-10 grid gap-8 lg:grid-cols-[1fr_0.42fr] lg:items-end">
+          <div className="animate-fade-in-up">
+            <div className="mb-5 flex flex-wrap items-center gap-3">
+              <span className="rounded-full bg-orange-100 px-3 py-1 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-orange-700 dark:bg-orange-950/50 dark:text-orange-300">
+                Case anonimizado
+              </span>
+              <span className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                {caseStudy.context}
+              </span>
+            </div>
+            <h1 className="text-4xl font-black leading-tight tracking-tight text-slate-950 dark:text-white sm:text-5xl lg:text-6xl">
+              {caseStudy.title}
+            </h1>
+            <p className="mt-6 max-w-3xl text-base leading-relaxed text-slate-600 dark:text-slate-300 sm:text-lg">
+              {details.intro}
+            </p>
+
+            <div className="mt-7 flex flex-wrap gap-2">
+              {details.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full border border-slate-200/80 bg-white/75 px-3 py-1.5 text-xs font-medium text-slate-700 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <aside className="rounded-2xl border border-orange-200/70 bg-gradient-to-br from-orange-50/90 to-red-50/70 p-5 dark:border-orange-900/60 dark:from-orange-950/30 dark:to-red-950/20 sm:p-6">
+            <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-red-500 to-orange-500 text-white shadow-lg">
+              <FaLayerGroup aria-hidden="true" className="h-5 w-5" />
+            </div>
+            <p className="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-orange-700 dark:text-orange-300">
+              Resultado em síntese
+            </p>
+            <p className="text-sm font-medium leading-relaxed text-slate-800 dark:text-slate-200">
+              {caseStudy.result}
+            </p>
+          </aside>
+        </div>
+
+        <div
+          aria-hidden="true"
+          className="absolute -right-16 -top-20 h-56 w-56 rounded-full bg-gradient-to-br from-orange-400/15 to-red-500/5 blur-3xl"
+        />
+      </header>
+
+      <section className="mb-16 sm:mb-20" aria-labelledby="challenge-title">
+        <SectionHeading
+          id="challenge-title"
+          eyebrow="Contexto"
+          title="O desafio"
+          subtitle="Modernizar sem transformar a operação em laboratório."
+          className="mb-8"
+        />
+
+        <div className="grid gap-5 lg:grid-cols-[1fr_0.75fr]">
+          <div className="rounded-2xl border border-slate-200/70 bg-white/60 p-5 dark:border-slate-700/70 dark:bg-slate-800/60 sm:p-7">
+            <p className="text-base leading-relaxed text-slate-700 dark:text-slate-300 sm:text-lg">
+              {details.challenge}
+            </p>
+            <p className="mt-6 border-l-2 border-orange-400 pl-4 text-sm leading-relaxed text-slate-500 dark:text-slate-400">
+              {details.confidentialityNote}
+            </p>
+          </div>
+
+          <ul className="grid gap-3">
+            {details.constraints.map((constraint) => (
+              <li
+                key={constraint}
+                className="flex gap-3 rounded-xl border border-slate-200/70 bg-white/55 p-4 text-sm leading-relaxed text-slate-700 dark:border-slate-700/70 dark:bg-slate-800/55 dark:text-slate-300"
+              >
+                <FaCheckCircle
+                  aria-hidden="true"
+                  className="mt-0.5 h-4 w-4 shrink-0 text-orange-500"
+                />
+                {constraint}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="mb-16 sm:mb-20" aria-labelledby="role-title">
+        <SectionHeading
+          id="role-title"
+          eyebrow="Responsabilidade"
+          title="Minha atuação"
+          subtitle="Do entendimento do legado à comprovação em produção."
+          className="mb-8"
+        />
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          {details.responsibilities.map((responsibility, index) => (
+            <article
+              key={responsibility}
+              className="flex gap-4 rounded-2xl border border-slate-200/70 bg-white/60 p-5 dark:border-slate-700/70 dark:bg-slate-800/60"
+            >
+              <span className="font-mono text-sm font-bold text-cyan-600 dark:text-cyan-300">
+                0{index + 1}
+              </span>
+              <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+                {responsibility}
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="mb-16 sm:mb-20" aria-labelledby="approach-title">
+        <SectionHeading
+          id="approach-title"
+          eyebrow="Estratégia"
+          title="A abordagem"
+          subtitle="Uma sequência repetível em vez de uma grande virada."
+          className="mb-8"
+        />
+
+        <ol className="grid gap-4 lg:grid-cols-4">
+          {details.approach.map((step) => (
+            <li
+              key={step.title}
+              className="relative overflow-hidden rounded-2xl border border-slate-200/70 bg-white/60 p-5 dark:border-slate-700/70 dark:bg-slate-800/60"
+            >
+              <p className="mb-3 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-cyan-700 dark:text-cyan-300">
+                {step.eyebrow}
+              </p>
+              <h3 className="mb-3 text-lg font-bold text-slate-900 dark:text-white">
+                {step.title}
+              </h3>
+              <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                {step.description}
+              </p>
+              <div
+                aria-hidden="true"
+                className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-cyan-500 via-blue-500 to-purple-500"
+              />
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <div className="mb-16 grid gap-5 lg:grid-cols-2">
+        <section
+          aria-labelledby="validation-title"
+          className="rounded-2xl border border-cyan-200/60 bg-cyan-50/60 p-5 dark:border-cyan-900/60 dark:bg-cyan-950/20 sm:p-7"
+        >
+          <SectionHeading
+            id="validation-title"
+            eyebrow="Evidência"
+            title="Como validei"
+            className="mb-7"
+          />
+          <ul className="space-y-4">
+            {details.validation.map((item) => (
+              <li
+                key={item}
+                className="flex gap-3 text-sm leading-relaxed text-slate-700 dark:text-slate-300"
+              >
+                <FaCheckCircle
+                  aria-hidden="true"
+                  className="mt-0.5 h-4 w-4 shrink-0 text-cyan-600 dark:text-cyan-300"
+                />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section
+          aria-labelledby="outcomes-title"
+          className="rounded-2xl border border-purple-200/60 bg-purple-50/60 p-5 dark:border-purple-900/60 dark:bg-purple-950/20 sm:p-7"
+        >
+          <SectionHeading
+            id="outcomes-title"
+            eyebrow="Resultado"
+            title="O que mudou"
+            className="mb-7"
+          />
+          <ul className="space-y-4">
+            {details.outcomes.map((item) => (
+              <li
+                key={item}
+                className="flex gap-3 text-sm leading-relaxed text-slate-700 dark:text-slate-300"
+              >
+                <FaCheckCircle
+                  aria-hidden="true"
+                  className="mt-0.5 h-4 w-4 shrink-0 text-purple-600 dark:text-purple-300"
+                />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      <section
+        aria-labelledby="case-contact-title"
+        className="rounded-2xl border border-slate-200/70 bg-gradient-to-br from-slate-50 via-cyan-50 to-purple-50 p-7 text-center dark:border-slate-700/70 dark:from-slate-900 dark:via-cyan-950/30 dark:to-purple-950/30 sm:p-10"
+      >
+        <h2
+          id="case-contact-title"
+          className="text-2xl font-bold text-slate-950 dark:text-white sm:text-3xl"
+        >
+          Precisa evoluir um sistema sem apostar tudo em uma reescrita?
+        </h2>
+        <p className="mx-auto mt-3 max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-300">
+          Podemos conversar sobre um caminho incremental, com regras explícitas,
+          entregas verificáveis e risco operacional controlado.
+        </p>
+        <Link
+          href="/#contato"
+          className="mt-7 inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-500 to-blue-600 px-7 py-3 font-semibold text-white shadow-lg shadow-cyan-500/20 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
+        >
+          Conversar sobre modernização
+          <FaArrowRight aria-hidden="true" className="h-4 w-4" />
+        </Link>
+      </section>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import Header from '../components/Header'
 import About from '../components/About'
 import EasterEggWrapper from '../components/EasterEggWrapper'
@@ -5,40 +6,19 @@ import Stack from '../components/Stack'
 import Contact from '../components/Contact'
 import Footer from '../components/Footer'
 import SectionHeading from '../components/SectionHeading'
-import { FaFileInvoice, FaLayerGroup, FaRocket } from 'react-icons/fa'
+import {
+  FaArrowRight,
+  FaFileInvoice,
+  FaLayerGroup,
+  FaRocket,
+} from 'react-icons/fa'
+import { caseStudies, type CaseStudyIcon } from '../data/case-studies'
 
-const caseStudies = [
-  {
-    title: 'Modernização sem ruptura',
-    context: 'Legado → Web',
-    description: 'Migração de sistemas Delphi e ERPs com regras críticas, evitando uma reescrita de alto risco.',
-    contribution: 'Arquitetura incremental, APIs, paridade e testes entre o legado e a nova experiência.',
-    result: 'Regras preservadas e evolução por etapas, com risco operacional controlado.',
-    icon: FaLayerGroup,
-    iconGradient: 'from-red-500 to-orange-500',
-    accent: 'text-orange-600 dark:text-orange-400',
-  },
-  {
-    title: 'Operações fiscais rastreáveis',
-    context: 'Fiscal & integrações',
-    description: 'Emissão e integrações em que schema, certificado, idempotência e disponibilidade formam um único contrato.',
-    contribution: 'APIs resilientes, observabilidade e estados explícitos de processamento e reenvio.',
-    result: 'Operações repetíveis e diagnóstico rápido entre sistema, fiscal e infraestrutura.',
-    icon: FaFileInvoice,
-    iconGradient: 'from-cyan-500 to-blue-600',
-    accent: 'text-cyan-700 dark:text-cyan-300',
-  },
-  {
-    title: 'Entrega que chega à produção',
-    context: 'CI/CD & plataforma',
-    description: 'Frontend, APIs, bancos e serviços que precisam continuar previsíveis depois que chegam à produção.',
-    contribution: 'Containers, pipelines, deploy automatizado e telemetria depois da entrega.',
-    result: 'Releases reproduzíveis e diagnóstico baseado em evidência, não em tentativa e erro.',
-    icon: FaRocket,
-    iconGradient: 'from-purple-500 to-violet-600',
-    accent: 'text-purple-700 dark:text-purple-300',
-  },
-]
+const caseStudyIcons: Record<CaseStudyIcon, typeof FaLayerGroup> = {
+  layers: FaLayerGroup,
+  invoice: FaFileInvoice,
+  rocket: FaRocket,
+}
 
 function FeaturedWork() {
   return (
@@ -57,7 +37,7 @@ function FeaturedWork() {
 
       <div className="grid gap-4 lg:grid-cols-3">
         {caseStudies.map((caseStudy) => {
-          const Icon = caseStudy.icon
+          const Icon = caseStudyIcons[caseStudy.icon]
 
           return (
             <article
@@ -98,6 +78,20 @@ function FeaturedWork() {
                   </dd>
                 </div>
               </dl>
+
+              {caseStudy.details && (
+                <Link
+                  href={`/cases/${caseStudy.slug}`}
+                  aria-label={`Ver case completo: ${caseStudy.title}`}
+                  className="mt-5 inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-orange-300/80 bg-orange-50/80 px-4 py-2.5 text-sm font-semibold text-orange-700 transition-all hover:-translate-y-0.5 hover:border-orange-400 hover:bg-orange-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 dark:border-orange-800/70 dark:bg-orange-950/30 dark:text-orange-300 dark:hover:border-orange-600 dark:hover:bg-orange-950/50"
+                >
+                  Ver case completo
+                  <FaArrowRight
+                    aria-hidden="true"
+                    className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5"
+                  />
+                </Link>
+              )}
 
               <div aria-hidden="true" className={`absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r ${caseStudy.iconGradient} opacity-70`} />
             </article>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import { MetadataRoute } from 'next'
+import { publishedCaseStudies } from '../data/case-studies'
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date()
@@ -16,5 +17,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.8,
     },
+    ...publishedCaseStudies.map(({ slug }) => ({
+      url: `https://andersondapper.com.br/cases/${slug}`,
+      lastModified,
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    })),
   ]
 }

--- a/src/data/case-studies.ts
+++ b/src/data/case-studies.ts
@@ -1,0 +1,151 @@
+export type CaseStudyIcon = 'layers' | 'invoice' | 'rocket'
+
+interface CaseStudyStep {
+  eyebrow: string
+  title: string
+  description: string
+}
+
+interface CaseStudyDetails {
+  intro: string
+  seoDescription: string
+  confidentialityNote: string
+  challenge: string
+  constraints: string[]
+  responsibilities: string[]
+  approach: CaseStudyStep[]
+  validation: string[]
+  outcomes: string[]
+  tags: string[]
+}
+
+export interface CaseStudy {
+  slug: string
+  title: string
+  context: string
+  description: string
+  contribution: string
+  result: string
+  icon: CaseStudyIcon
+  iconGradient: string
+  accent: string
+  details?: CaseStudyDetails
+}
+
+export type PublishedCaseStudy = CaseStudy & {
+  details: CaseStudyDetails
+}
+
+export const caseStudies: CaseStudy[] = [
+  {
+    slug: 'modernizacao-sem-ruptura',
+    title: 'Modernização sem ruptura',
+    context: 'Legado → Web',
+    description:
+      'Migração de sistemas Delphi e ERPs com regras críticas, evitando uma reescrita de alto risco.',
+    contribution:
+      'Arquitetura incremental, APIs, paridade e testes entre o legado e a nova experiência.',
+    result:
+      'Regras preservadas e evolução por etapas, com risco operacional controlado.',
+    icon: 'layers',
+    iconGradient: 'from-red-500 to-orange-500',
+    accent: 'text-orange-600 dark:text-orange-400',
+    details: {
+      intro:
+        'Um recorte de como evoluir um sistema Delphi maduro para uma experiência web sem interromper a operação nem descartar as regras que o negócio consolidou ao longo dos anos.',
+      seoDescription:
+        'Case anonimizado de modernização incremental de sistemas Delphi para Web e APIs, com paridade funcional, validação contínua e risco operacional controlado.',
+      confidentialityNote:
+        'Este relato preserva nomes, volumes, telas e dados do projeto. O foco está no problema de engenharia, nas decisões tomadas e nos critérios usados para validar a evolução.',
+      challenge:
+        'O sistema existente concentrava anos de comportamento operacional em telas, validações, consultas e integrações. Uma reescrita total criaria um longo período sem entrega e transformaria regras conhecidas em hipóteses.',
+      constraints: [
+        'A operação precisava continuar durante toda a transição.',
+        'Parte das regras estava implícita no comportamento do sistema legado.',
+        'Usuários precisavam reconhecer fluxos e resultados na nova experiência.',
+        'Legado e Web coexistiriam até que cada recorte estivesse validado.',
+      ],
+      responsibilities: [
+        'Inventariar fluxos, estados, regras e dependências antes da conversão.',
+        'Definir a arquitetura incremental e os contratos entre interface, APIs e dados.',
+        'Converter recortes verticais com rastreabilidade até o comportamento legado.',
+        'Separar prova local, testes, integração, deploy e saúde em produção.',
+      ],
+      approach: [
+        {
+          eyebrow: '01 · Baseline',
+          title: 'Congelar e mapear',
+          description:
+            'Cada recorte começava com uma referência estável do legado e um mapa explícito de telas, regras, dados e integrações envolvidas.',
+        },
+        {
+          eyebrow: '02 · Contratos',
+          title: 'Criar limites claros',
+          description:
+            'APIs e modelos transformavam comportamento implícito em contratos revisáveis, reduzindo o acoplamento com a aplicação original.',
+        },
+        {
+          eyebrow: '03 · Paridade',
+          title: 'Migrar fatias completas',
+          description:
+            'Interface, regra, persistência e validação avançavam juntas. Cada fluxo novo precisava demonstrar equivalência antes de substituir o anterior.',
+        },
+        {
+          eyebrow: '04 · Operação',
+          title: 'Validar além do build',
+          description:
+            'A entrega só era considerada pronta depois de integração, deploy, navegação real e sinais de saúde coerentes com o commit publicado.',
+        },
+      ],
+      validation: [
+        'Comportamentos e estados comparados com referências do sistema legado.',
+        'Regras críticas cobertas por testes e cenários de integração.',
+        'Fluxos completos exercitados na interface e nas APIs.',
+        'Deploy e funcionamento real verificados separadamente do build.',
+      ],
+      outcomes: [
+        'Regras de negócio preservadas sem depender de uma troca abrupta.',
+        'Evolução dividida em entregas menores e verificáveis.',
+        'Risco operacional controlado pela convivência temporária entre as soluções.',
+        'Uma base reutilizável para converter novos módulos com o mesmo método.',
+      ],
+      tags: ['Delphi', 'Web', 'APIs REST', 'Paridade funcional', 'Entrega incremental'],
+    },
+  },
+  {
+    slug: 'operacoes-fiscais-rastreaveis',
+    title: 'Operações fiscais rastreáveis',
+    context: 'Fiscal & integrações',
+    description:
+      'Emissão e integrações em que schema, certificado, idempotência e disponibilidade formam um único contrato.',
+    contribution:
+      'APIs resilientes, observabilidade e estados explícitos de processamento e reenvio.',
+    result:
+      'Operações repetíveis e diagnóstico rápido entre sistema, fiscal e infraestrutura.',
+    icon: 'invoice',
+    iconGradient: 'from-cyan-500 to-blue-600',
+    accent: 'text-cyan-700 dark:text-cyan-300',
+  },
+  {
+    slug: 'entrega-que-chega-a-producao',
+    title: 'Entrega que chega à produção',
+    context: 'CI/CD & plataforma',
+    description:
+      'Frontend, APIs, bancos e serviços que precisam continuar previsíveis depois que chegam à produção.',
+    contribution:
+      'Containers, pipelines, deploy automatizado e telemetria depois da entrega.',
+    result:
+      'Releases reproduzíveis e diagnóstico baseado em evidência, não em tentativa e erro.',
+    icon: 'rocket',
+    iconGradient: 'from-purple-500 to-violet-600',
+    accent: 'text-purple-700 dark:text-purple-300',
+  },
+]
+
+export const publishedCaseStudies = caseStudies.filter(
+  (caseStudy): caseStudy is PublishedCaseStudy => caseStudy.details !== undefined,
+)
+
+export function getPublishedCaseStudy(slug: string) {
+  return publishedCaseStudies.find((caseStudy) => caseStudy.slug === slug)
+}

--- a/src/data/case-studies.ts
+++ b/src/data/case-studies.ts
@@ -6,17 +6,31 @@ interface CaseStudyStep {
   description: string
 }
 
+interface CaseStudyCallToAction {
+  title: string
+  description: string
+  label: string
+}
+
+interface CaseStudySectionSubtitles {
+  challenge: string
+  responsibilities: string
+  approach: string
+}
+
 interface CaseStudyDetails {
   intro: string
   seoDescription: string
   confidentialityNote: string
   challenge: string
+  sectionSubtitles: CaseStudySectionSubtitles
   constraints: string[]
   responsibilities: string[]
   approach: CaseStudyStep[]
   validation: string[]
   outcomes: string[]
   tags: string[]
+  callToAction: CaseStudyCallToAction
 }
 
 export interface CaseStudy {
@@ -59,6 +73,11 @@ export const caseStudies: CaseStudy[] = [
         'Este relato preserva nomes, volumes, telas e dados do projeto. O foco está no problema de engenharia, nas decisões tomadas e nos critérios usados para validar a evolução.',
       challenge:
         'O sistema existente concentrava anos de comportamento operacional em telas, validações, consultas e integrações. Uma reescrita total criaria um longo período sem entrega e transformaria regras conhecidas em hipóteses.',
+      sectionSubtitles: {
+        challenge: 'Modernizar sem transformar a operação em laboratório.',
+        responsibilities: 'Do entendimento do legado à comprovação em produção.',
+        approach: 'Uma sequência repetível em vez de uma grande virada.',
+      },
       constraints: [
         'A operação precisava continuar durante toda a transição.',
         'Parte das regras estava implícita no comportamento do sistema legado.',
@@ -110,6 +129,12 @@ export const caseStudies: CaseStudy[] = [
         'Uma base reutilizável para converter novos módulos com o mesmo método.',
       ],
       tags: ['Delphi', 'Web', 'APIs REST', 'Paridade funcional', 'Entrega incremental'],
+      callToAction: {
+        title: 'Precisa evoluir um sistema sem apostar tudo em uma reescrita?',
+        description:
+          'Podemos conversar sobre um caminho incremental, com regras explícitas, entregas verificáveis e risco operacional controlado.',
+        label: 'Conversar sobre modernização',
+      },
     },
   },
   {
@@ -125,6 +150,78 @@ export const caseStudies: CaseStudy[] = [
     icon: 'invoice',
     iconGradient: 'from-cyan-500 to-blue-600',
     accent: 'text-cyan-700 dark:text-cyan-300',
+    details: {
+      intro:
+        'Um recorte de como tornar emissões e integrações fiscais previsíveis quando certificados, schemas, serviços externos e tentativas repetidas fazem parte da mesma operação.',
+      seoDescription:
+        'Case anonimizado de engenharia fiscal com APIs idempotentes, estados explícitos e observabilidade para emissões e integrações rastreáveis.',
+      confidentialityNote:
+        'Este relato não expõe clientes, documentos, volumes ou provedores. Ele descreve os limites técnicos, as decisões de arquitetura e as evidências usadas para validar a operação.',
+      challenge:
+        'Uma emissão fiscal não termina quando a API aceita a requisição. Assinatura, schema, certificado, disponibilidade externa, recibos, rejeições e reenvios precisam formar uma única história operacional — inclusive quando uma resposta se perde no caminho.',
+      sectionSubtitles: {
+        challenge: 'Integrar sem perder a história do que aconteceu.',
+        responsibilities: 'Do contrato de entrada à evidência operacional.',
+        approach: 'Identidade, estado e evidência em uma única sequência.',
+      },
+      constraints: [
+        'Uma repetição após timeout não poderia criar uma segunda operação fiscal.',
+        'Certificados, ambientes e schemas mudavam o comportamento da integração.',
+        'Indisponibilidades externas precisavam ser separadas de rejeições de negócio.',
+        'O suporte precisava reconstruir cada tentativa sem depender de suposições.',
+      ],
+      responsibilities: [
+        'Modelar identidade, estados e transições da operação fiscal de ponta a ponta.',
+        'Definir contratos de API, validação de payload e limites de idempotência.',
+        'Separar falhas transitórias, rejeições fiscais e erros internos recuperáveis.',
+        'Correlacionar requisição, documento, retorno externo e reprocessamento na telemetria.',
+      ],
+      approach: [
+        {
+          eyebrow: '01 · Contrato',
+          title: 'Identificar a operação',
+          description:
+            'Cada emissão ganhava uma identidade estável, regras de entrada explícitas e uma resposta coerente mesmo quando a chamada era repetida.',
+        },
+        {
+          eyebrow: '02 · Estados',
+          title: 'Explicitar a jornada',
+          description:
+            'Processamento, autorização, rejeição e contingência deixavam de ser efeitos colaterais e passavam a formar uma máquina de estados consultável.',
+        },
+        {
+          eyebrow: '03 · Resiliência',
+          title: 'Repetir com segurança',
+          description:
+            'Timeouts e indisponibilidades eram tratados com reconsulta e reprocessamento controlados, sem confundir ausência de resposta com ausência de resultado.',
+        },
+        {
+          eyebrow: '04 · Evidência',
+          title: 'Ligar todos os sinais',
+          description:
+            'Logs estruturados e correlação conectavam API, documento, serviço fiscal e infraestrutura em uma linha do tempo única para diagnóstico.',
+        },
+      ],
+      validation: [
+        'Payloads e documentos validados contra contratos e schemas aplicáveis.',
+        'Requisições repetidas exercitadas para comprovar o mesmo resultado operacional.',
+        'Timeouts, rejeições e indisponibilidades simulados como cenários distintos.',
+        'Rastreabilidade verificada da entrada até o retorno e eventuais reprocessamentos.',
+      ],
+      outcomes: [
+        'Reenvios controlados sem transformar retry em duplicidade fiscal.',
+        'Estados compreensíveis para aplicação, suporte e operação.',
+        'Diagnóstico baseado em uma linha do tempo correlacionada.',
+        'Integrações mais previsíveis mesmo diante de dependências externas.',
+      ],
+      tags: ['NF-e', 'APIs', 'Idempotência', 'Observabilidade', 'Integrações'],
+      callToAction: {
+        title: 'Precisa tornar uma operação fiscal previsível de ponta a ponta?',
+        description:
+          'Podemos conversar sobre contratos explícitos, idempotência e observabilidade para integrações que precisam sobreviver a condições reais.',
+        label: 'Conversar sobre integrações fiscais',
+      },
+    },
   },
   {
     slug: 'entrega-que-chega-a-producao',

--- a/src/data/case-studies.ts
+++ b/src/data/case-studies.ts
@@ -236,6 +236,78 @@ export const caseStudies: CaseStudy[] = [
     icon: 'rocket',
     iconGradient: 'from-purple-500 to-violet-600',
     accent: 'text-purple-700 dark:text-purple-300',
+    details: {
+      intro:
+        'Um recorte de como transformar código aprovado em uma release previsível, conectando artefato, configuração, banco de dados, deploy e sinais de saúde à mesma versão.',
+      seoDescription:
+        'Case anonimizado de entrega contínua com containers, pipelines, deploy rastreável e observabilidade para releases reproduzíveis.',
+      confidentialityNote:
+        'Este relato preserva nomes de serviços, ambientes e detalhes de infraestrutura. O foco está no desenho da entrega, nas decisões operacionais e nas provas usadas para confirmar cada release.',
+      challenge:
+        'Um pipeline verde comprova que etapas terminaram, mas não que a versão correta está atendendo usuários. Entre o commit e a produção existem artefatos, configurações, migrações, dependências e mecanismos de deploy que também precisam ser tratados como parte do produto.',
+      sectionSubtitles: {
+        challenge: 'Fechar a distância entre commit e operação.',
+        responsibilities: 'Da definição do pipeline à prova da versão ativa.',
+        approach: 'Evidência em cada transição da cadeia de entrega.',
+      },
+      constraints: [
+        'Frontend, APIs, bancos e serviços precisavam evoluir sem um deploy indivisível.',
+        'Diferenças de configuração entre ambientes não poderiam invalidar o build aprovado.',
+        'Cada publicação precisava indicar artefato, revisão e caminho de recuperação.',
+        'Job concluído, serviço iniciado e operação saudável eram provas diferentes.',
+      ],
+      responsibilities: [
+        'Mapear estágios, dependências, artefatos e critérios de promoção da release.',
+        'Padronizar containers e separar configuração de ambiente do código construído.',
+        'Coordenar mudanças de aplicação e banco com compatibilidade durante o deploy.',
+        'Conectar pipeline, plataforma e telemetria à revisão efetivamente publicada.',
+      ],
+      approach: [
+        {
+          eyebrow: '01 · Artefato',
+          title: 'Construir uma vez',
+          description:
+            'A mesma saída versionada avançava pelos ambientes, evitando recompilações que pudessem mudar silenciosamente o conteúdo aprovado.',
+        },
+        {
+          eyebrow: '02 · Critérios',
+          title: 'Separar as provas',
+          description:
+            'Qualidade do código, geração do artefato, publicação e saúde em execução tinham verificações próprias e resultados identificáveis.',
+        },
+        {
+          eyebrow: '03 · Rollout',
+          title: 'Implantar com contrato',
+          description:
+            'Configuração, dependências, mudanças de dados e ordem de atualização eram tratadas como entradas explícitas do deploy, não como conhecimento informal.',
+        },
+        {
+          eyebrow: '04 · Runtime',
+          title: 'Provar a versão ativa',
+          description:
+            'Revisão publicada, endpoints de saúde, logs e telemetria confirmavam separadamente que a entrega chegou e permaneceu operacional.',
+        },
+      ],
+      validation: [
+        'O mesmo artefato versionado promovido entre os ambientes previstos.',
+        'Falhas de qualidade, build e publicação verificadas em estágios distintos.',
+        'Revisão ativa, configuração, mudanças de dados e saúde conferidas após o deploy.',
+        'Reexecução e recuperação exercitadas sem depender de passos não documentados.',
+      ],
+      outcomes: [
+        'Releases reproduzíveis, identificáveis e mais simples de promover.',
+        'Menos divergência causada por configuração ou recompilação entre ambientes.',
+        'Falhas localizadas na etapa que realmente precisa de intervenção.',
+        'Diagnóstico operacional ligado à revisão publicada, e não a suposições.',
+      ],
+      tags: ['CI/CD', 'Containers', 'Deploy', 'Observabilidade', 'Plataforma'],
+      callToAction: {
+        title: 'Precisa que a entrega continue previsível depois do merge?',
+        description:
+          'Podemos conversar sobre uma cadeia de entrega reproduzível, com critérios claros de promoção e evidência da versão realmente ativa.',
+        label: 'Conversar sobre entrega e plataforma',
+      },
+    },
   },
 ]
 


### PR DESCRIPTION
## Resumo

- centraliza os cards do portfólio em uma fonte de dados compartilhada
- adiciona cases anonimizados de modernização, operações fiscais e entrega em produção
- cria páginas estáticas com conteúdo, identidade visual e CTA próprios para cada case
- conecta os três cases à home, aos metadados e ao sitemap
- evita imagens sociais genéricas nas páginas de detalhe

## Validação

- `corepack pnpm@10.34.5 lint`
- `corepack pnpm@10.34.5 build`
- `corepack pnpm@10.34.5 exec tsc --noEmit --incremental false`
- revisão local dos três cases