### PR TITLE
feat: adiciona hub de cases e instrumentação

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "next": "16.3.2",
     "next-themes": "^0.4.6",
     "react": "^19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.3.2(@babel/core@7.29.7)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       next:
         specifier: 16.3.2
         version: 16.3.2(@babel/core@7.29.7)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -756,6 +759,35 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2655,6 +2687,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vercel/analytics@2.0.1(next@16.3.2(@babel/core@7.29.7)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    optionalDependencies:
+      next: 16.3.2(@babel/core@7.29.7)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
 
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -75,7 +75,7 @@ export default function AboutPage() {
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row">
             <Link
-              href="/#projetos"
+              href="/cases"
               className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-500 to-blue-600 px-6 py-3 font-semibold text-white shadow-lg shadow-cyan-500/20 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
             >
               Ver cases

--- a/src/app/cases/[slug]/page.tsx
+++ b/src/app/cases/[slug]/page.tsx
@@ -58,9 +58,64 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
 
   const { details } = caseStudy
   const visual = caseStudyVisuals[caseStudy.icon]
+  const caseUrl = `https://andersondapper.com.br/cases/${caseStudy.slug}`
+  const caseStructuredData = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Article',
+        '@id': `${caseUrl}#case`,
+        headline: caseStudy.title,
+        description: details.seoDescription,
+        url: caseUrl,
+        mainEntityOfPage: caseUrl,
+        articleSection: caseStudy.context,
+        keywords: details.tags.join(', '),
+        inLanguage: 'pt-BR',
+        author: {
+          '@id': 'https://andersondapper.com.br/#person',
+        },
+        publisher: {
+          '@id': 'https://andersondapper.com.br/#person',
+        },
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Início',
+            item: 'https://andersondapper.com.br',
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Cases',
+            item: 'https://andersondapper.com.br/cases',
+          },
+          {
+            '@type': 'ListItem',
+            position: 3,
+            name: caseStudy.title,
+            item: caseUrl,
+          },
+        ],
+      },
+    ],
+  }
+  const serializedCaseStructuredData = JSON.stringify(caseStructuredData).replace(
+    /</g,
+    '\\u003c',
+  )
 
   return (
     <div>
+      <script
+        id="case-structured-data"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializedCaseStructuredData }}
+      />
       <nav aria-label="Navegação do case" className="mb-8 flex items-center justify-between gap-4 animate-fade-in">
         <Link
           href="/cases"

--- a/src/app/cases/[slug]/page.tsx
+++ b/src/app/cases/[slug]/page.tsx
@@ -63,7 +63,7 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
     <div>
       <nav aria-label="Navegação do case" className="mb-8 flex items-center justify-between gap-4 animate-fade-in">
         <Link
-          href="/#projetos"
+          href="/cases"
           className="group inline-flex min-h-11 items-center gap-2 rounded-lg px-2 text-sm font-medium text-slate-500 transition-colors hover:text-cyan-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 dark:text-slate-400 dark:hover:text-cyan-300"
         >
           <FaArrowLeft

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -1,0 +1,207 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { FaArrowLeft, FaArrowRight, FaCheckCircle } from 'react-icons/fa'
+import SectionHeading from '../../components/SectionHeading'
+import ThemeToggle from '../../components/ThemeToggle'
+import { publishedCaseStudies } from '../../data/case-studies'
+
+const pageDescription =
+  'Cases anonimizados de modernização de sistemas, operações fiscais e entrega contínua, com decisões, validações e resultados de engenharia.'
+
+export const metadata: Metadata = {
+  title: 'Cases',
+  description: pageDescription,
+  alternates: {
+    canonical: '/cases',
+  },
+  openGraph: {
+    type: 'website',
+    url: '/cases',
+    title: 'Cases de engenharia | Anderson Dapper',
+    description: pageDescription,
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Anderson Dapper - Software legado, APIs e Web',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Cases de engenharia | Anderson Dapper',
+    description: pageDescription,
+    images: ['/og-image.png'],
+  },
+}
+
+export default function CasesPage() {
+  return (
+    <div>
+      <nav
+        aria-label="Navegação da página"
+        className="mb-8 flex items-center justify-between gap-4 animate-fade-in"
+      >
+        <Link
+          href="/"
+          className="group inline-flex min-h-11 items-center gap-2 rounded-lg px-2 text-sm font-medium text-slate-500 transition-colors hover:text-cyan-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 dark:text-slate-400 dark:hover:text-cyan-300"
+        >
+          <FaArrowLeft
+            aria-hidden="true"
+            className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-1"
+          />
+          Voltar para a página inicial
+        </Link>
+        <ThemeToggle />
+      </nav>
+
+      <header className="relative mb-16 overflow-hidden rounded-3xl border border-slate-200/70 bg-white/55 px-5 py-10 dark:border-slate-700/70 dark:bg-slate-900/45 sm:px-8 sm:py-14 lg:px-12">
+        <div className="relative z-10 max-w-3xl animate-fade-in-up">
+          <p className="mb-4 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-cyan-700 dark:text-cyan-300">
+            Portfólio · engenharia em contexto real
+          </p>
+          <h1 className="text-4xl font-black leading-tight tracking-tight text-slate-950 dark:text-white sm:text-5xl lg:text-6xl">
+            Cases do legado à produção.
+          </h1>
+          <p className="mt-6 max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-300 sm:text-lg">
+            Três recortes anonimizados sobre problemas que não terminam no código:
+            regras acumuladas, integrações externas e a responsabilidade de manter a
+            entrega saudável depois do deploy.
+          </p>
+
+          <div className="mt-7 flex flex-wrap gap-2">
+            {publishedCaseStudies.map((caseStudy) => (
+              <span
+                key={caseStudy.slug}
+                className="rounded-full border border-slate-200/80 bg-white/75 px-3 py-1.5 text-xs font-medium text-slate-700 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200"
+              >
+                {caseStudy.context}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div
+          aria-hidden="true"
+          className="absolute -right-16 -top-20 h-56 w-56 rounded-full bg-gradient-to-br from-cyan-400/20 to-blue-500/5 blur-3xl"
+        />
+        <div
+          aria-hidden="true"
+          className="absolute -bottom-24 right-1/4 h-52 w-52 rounded-full bg-gradient-to-br from-purple-500/15 to-transparent blur-3xl"
+        />
+      </header>
+
+      <section className="mb-16 sm:mb-20" aria-labelledby="cases-title">
+        <SectionHeading
+          id="cases-title"
+          eyebrow="Trabalho em contexto real"
+          title="Escolha um recorte"
+          subtitle="Cada case explicita o desafio, minha atuação, a abordagem e como o resultado foi validado."
+          className="mb-8"
+        />
+
+        <div className="grid gap-5">
+          {publishedCaseStudies.map((caseStudy, index) => (
+            <article
+              key={caseStudy.slug}
+              className="group relative overflow-hidden rounded-2xl border border-slate-200/70 bg-white/60 p-5 shadow-sm transition-all hover:-translate-y-1 hover:shadow-xl dark:border-slate-700/70 dark:bg-slate-800/60 sm:p-7"
+            >
+              <div className="grid gap-7 lg:grid-cols-[0.82fr_1.18fr] lg:items-center">
+                <div>
+                  <div className="mb-4 flex items-center gap-3">
+                    <span className="font-mono text-xs font-bold text-slate-400 dark:text-slate-500">
+                      0{index + 1}
+                    </span>
+                    <span className={`font-mono text-xs font-semibold uppercase tracking-[0.16em] ${caseStudy.accent}`}>
+                      {caseStudy.context}
+                    </span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-950 dark:text-white sm:text-3xl">
+                    {caseStudy.title}
+                  </h2>
+                  <p className="mt-4 text-sm leading-relaxed text-slate-600 dark:text-slate-300 sm:text-base">
+                    {caseStudy.description}
+                  </p>
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    {caseStudy.details.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="rounded-full border border-slate-200/80 bg-slate-50/80 px-3 py-1 text-xs font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="grid gap-4">
+                  <div className="rounded-xl border border-slate-200/70 bg-white/65 p-4 dark:border-slate-700/70 dark:bg-slate-900/45">
+                    <p className="mb-2 text-xs font-bold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+                      Minha contribuição
+                    </p>
+                    <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+                      {caseStudy.contribution}
+                    </p>
+                  </div>
+                  <div className="flex gap-3 rounded-xl border border-emerald-200/60 bg-emerald-50/60 p-4 dark:border-emerald-900/50 dark:bg-emerald-950/20">
+                    <FaCheckCircle
+                      aria-hidden="true"
+                      className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400"
+                    />
+                    <div>
+                      <p className="mb-1 text-xs font-bold uppercase tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
+                        Resultado
+                      </p>
+                      <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+                        {caseStudy.result}
+                      </p>
+                    </div>
+                  </div>
+                  <Link
+                    href={`/cases/${caseStudy.slug}`}
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-cyan-300/80 bg-cyan-50/80 px-4 py-2.5 text-sm font-semibold text-cyan-800 transition-all hover:-translate-y-0.5 hover:border-cyan-400 hover:bg-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 dark:border-cyan-800/70 dark:bg-cyan-950/30 dark:text-cyan-300 dark:hover:border-cyan-600 dark:hover:bg-cyan-950/50"
+                  >
+                    Explorar case
+                    <FaArrowRight
+                      aria-hidden="true"
+                      className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5"
+                    />
+                  </Link>
+                </div>
+              </div>
+
+              <div
+                aria-hidden="true"
+                className={`absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r ${caseStudy.iconGradient}`}
+              />
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="cases-contact-title"
+        className="rounded-2xl border border-slate-200/70 bg-gradient-to-br from-slate-50 via-cyan-50 to-purple-50 p-7 text-center dark:border-slate-700/70 dark:from-slate-900 dark:via-cyan-950/30 dark:to-purple-950/30 sm:p-10"
+      >
+        <h2
+          id="cases-contact-title"
+          className="text-2xl font-bold text-slate-950 dark:text-white sm:text-3xl"
+        >
+          Tem um desafio que atravessa mais de uma dessas frentes?
+        </h2>
+        <p className="mx-auto mt-3 max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-300">
+          Podemos conversar sobre um caminho que conecte produto, arquitetura e
+          operação sem perder o contexto do negócio.
+        </p>
+        <Link
+          href="/#contato"
+          className="mt-7 inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-500 to-blue-600 px-7 py-3 font-semibold text-white shadow-lg shadow-cyan-500/20 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
+        >
+          Conversar sobre o desafio
+          <FaArrowRight aria-hidden="true" className="h-4 w-4" />
+        </Link>
+      </section>
+    </div>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import { Providers } from '../context/ThemeContext'
+import SiteAnalytics from '../components/SiteAnalytics'
 import { Inter } from 'next/font/google'
 
 const inter = Inter({ 
@@ -14,6 +15,45 @@ const siteUrl = 'https://andersondapper.com.br'
 const siteName = 'Anderson Dapper'
 const siteTitle = 'Anderson Dapper | Software legado, APIs e Web'
 const siteDescription = 'Modernização de sistemas críticos, APIs e produtos web com mais de 20 anos de experiência. Do legado à plataforma, sem perder as regras do negócio.'
+const siteStructuredData = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'Person',
+      '@id': `${siteUrl}/#person`,
+      name: siteName,
+      url: siteUrl,
+      sameAs: [
+        'https://linkedin.com/in/andersondapper',
+        'https://github.com/toppermitz',
+      ],
+      knowsAbout: [
+        'Modernização de sistemas legados',
+        'APIs',
+        'Produtos web',
+        'Delphi',
+        'TypeScript',
+        'PostgreSQL',
+        'CI/CD',
+      ],
+    },
+    {
+      '@type': 'WebSite',
+      '@id': `${siteUrl}/#website`,
+      url: siteUrl,
+      name: siteName,
+      description: siteDescription,
+      inLanguage: 'pt-BR',
+      publisher: {
+        '@id': `${siteUrl}/#person`,
+      },
+    },
+  ],
+}
+const serializedSiteStructuredData = JSON.stringify(siteStructuredData).replace(
+  /</g,
+  '\\u003c',
+)
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
@@ -69,6 +109,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="pt-br" className={inter.variable} suppressHydrationWarning>
       <body className="font-sans bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 min-h-screen overflow-x-hidden" suppressHydrationWarning>
+        <script
+          id="site-structured-data"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: serializedSiteStructuredData }}
+        />
         <Providers>
           {/* Background - static gradient, no blur animations */}
           <div className="fixed inset-0 overflow-hidden pointer-events-none">
@@ -86,6 +131,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </main>
           </div>
         </Providers>
+        <SiteAnalytics />
       </body>
     </html>
   )

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -17,6 +17,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.8,
     },
+    {
+      url: 'https://andersondapper.com.br/cases',
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.9,
+    },
     ...publishedCaseStudies.map(({ slug }) => ({
       url: `https://andersondapper.com.br/cases/${slug}`,
       lastModified,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,6 @@
 import Image from 'next/image'
+import Link from 'next/link'
+import { FaArrowRight } from 'react-icons/fa'
 import ThemeToggle from './ThemeToggle'
 
 export default function Header() {
@@ -45,15 +47,13 @@ export default function Header() {
           </p>
 
           <div className="mt-7 flex w-full flex-col justify-center gap-3 sm:w-auto sm:flex-row">
-            <a
-              href="#projetos"
+            <Link
+              href="/cases"
               className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-500 to-blue-600 px-6 py-3 font-semibold text-white shadow-lg shadow-cyan-500/20 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-xl hover:shadow-cyan-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
             >
               Ver cases
-              <svg aria-hidden="true" className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
-              </svg>
-            </a>
+              <FaArrowRight aria-hidden="true" className="h-4 w-4" />
+            </Link>
             <a
               href="mailto:eu@andersondapper.com.br"
               className="inline-flex min-h-12 items-center justify-center rounded-xl border border-slate-300/80 bg-white/60 px-6 py-3 font-semibold text-slate-800 transition-all duration-300 hover:-translate-y-0.5 hover:border-purple-400 hover:bg-white dark:border-slate-600 dark:bg-slate-800/60 dark:text-slate-100 dark:hover:border-purple-400 dark:hover:bg-slate-800"

--- a/src/components/SiteAnalytics.tsx
+++ b/src/components/SiteAnalytics.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+import { Analytics } from '@vercel/analytics/next'
+import { track } from '@vercel/analytics/react'
+
+function classifyLink(link: HTMLAnchorElement) {
+  const href = link.getAttribute('href')
+
+  if (!href) {
+    return null
+  }
+
+  if (href.startsWith('mailto:')) {
+    return 'email'
+  }
+
+  const destination = new URL(href, window.location.href)
+
+  if (destination.hostname === 'linkedin.com' || destination.hostname.endsWith('.linkedin.com')) {
+    return 'linkedin'
+  }
+
+  if (destination.hostname === 'github.com' || destination.hostname.endsWith('.github.com')) {
+    return 'github'
+  }
+
+  if (destination.pathname === '/cases') {
+    return 'cases_hub'
+  }
+
+  if (destination.pathname.startsWith('/cases/')) {
+    return 'case_detail'
+  }
+
+  if (destination.hash === '#contato') {
+    return 'contact_section'
+  }
+
+  return null
+}
+
+export default function SiteAnalytics() {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      if (!(event.target instanceof Element)) {
+        return
+      }
+
+      const link = event.target.closest('a')
+
+      if (!(link instanceof HTMLAnchorElement)) {
+        return
+      }
+
+      const target = classifyLink(link)
+
+      if (!target) {
+        return
+      }
+
+      const label = link.textContent?.trim().replace(/\s+/g, ' ').slice(0, 80) || 'link'
+
+      track('CTA Click', {
+        target,
+        source: pathname,
+        label,
+      })
+    }
+
+    document.addEventListener('click', handleClick)
+
+    return () => document.removeEventListener('click', handleClick)
+  }, [pathname])
+
+  return <Analytics />
+}


### PR DESCRIPTION
## Resumo

- cria o hub `/cases` com os três trabalhos e seus principais resultados
- centraliza a navegação da home, página Sobre e detalhes no novo hub
- adiciona metadata, imagem social, canonical e sitemap para a página
- publica dados estruturados `Person`, `WebSite`, `Article` e `BreadcrumbList`
- integra Vercel Web Analytics e mede abertura de cases e contatos sem enviar conteúdo pessoal

## Fases

- **5A — Hub de cases:** experiência central de navegação e descoberta
- **5B — SEO e conversão:** dados estruturados e eventos de CTA

## Validação

- `corepack pnpm@10.34.5 install --frozen-lockfile`
- `corepack pnpm@10.34.5 lint`
- `corepack pnpm@10.34.5 build`
- `corepack pnpm@10.34.5 exec tsc --noEmit --incremental false`
- rotas estáticas `/cases` e os três detalhes geradas
- JSON-LD validado para o site e os três cases
- links da home, Sobre, hub, detalhes e sitemap conferidos

## Operação

A coleta depende do Web Analytics estar habilitado no projeto da Vercel.