### PR TITLE
feat: adiciona área de insights técnicos

### DIFF
--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -1,0 +1,296 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { FaArrowLeft, FaArrowRight, FaCheckCircle, FaClock } from 'react-icons/fa'
+import SectionHeading from '../../../components/SectionHeading'
+import ThemeToggle from '../../../components/ThemeToggle'
+import { getPublishedInsight, publishedInsights } from '../../../data/insights'
+
+interface InsightPageProps {
+  params: Promise<{ slug: string }>
+}
+
+export function generateStaticParams() {
+  return publishedInsights.map(({ slug }) => ({ slug }))
+}
+
+export async function generateMetadata({ params }: InsightPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const insight = getPublishedInsight(slug)
+
+  if (!insight) {
+    return {}
+  }
+
+  const canonical = `/insights/${insight.slug}`
+
+  return {
+    title: insight.title,
+    description: insight.description,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      type: 'article',
+      url: canonical,
+      title: insight.title,
+      description: insight.description,
+      publishedTime: insight.publishedAt,
+      authors: ['https://andersondapper.com.br'],
+      images: [],
+    },
+    twitter: {
+      card: 'summary',
+      title: insight.title,
+      description: insight.description,
+      images: [],
+    },
+  }
+}
+
+export default async function InsightPage({ params }: InsightPageProps) {
+  const { slug } = await params
+  const insight = getPublishedInsight(slug)
+
+  if (!insight) {
+    notFound()
+  }
+
+  const insightUrl = `https://andersondapper.com.br/insights/${insight.slug}`
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Article',
+        '@id': `${insightUrl}#article`,
+        headline: insight.title,
+        description: insight.description,
+        url: insightUrl,
+        mainEntityOfPage: insightUrl,
+        datePublished: insight.publishedAt,
+        dateModified: insight.publishedAt,
+        articleSection: insight.category,
+        keywords: insight.tags.join(', '),
+        inLanguage: 'pt-BR',
+        author: {
+          '@id': 'https://andersondapper.com.br/#person',
+        },
+        publisher: {
+          '@id': 'https://andersondapper.com.br/#person',
+        },
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Início',
+            item: 'https://andersondapper.com.br',
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Insights',
+            item: 'https://andersondapper.com.br/insights',
+          },
+          {
+            '@type': 'ListItem',
+            position: 3,
+            name: insight.title,
+            item: insightUrl,
+          },
+        ],
+      },
+    ],
+  }
+  const serializedStructuredData = JSON.stringify(structuredData).replace(/</g, '\\u003c')
+
+  return (
+    <div>
+      <script
+        id="insight-structured-data"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializedStructuredData }}
+      />
+      <nav
+        aria-label="Navegação do artigo"
+        className="mb-8 flex items-center justify-between gap-4 animate-fade-in"
+      >
+        <Link
+          href="/insights"
+          className="group inline-flex min-h-11 items-center gap-2 rounded-lg px-2 text-sm font-medium text-slate-500 transition-colors hover:text-purple-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 dark:text-slate-400 dark:hover:text-purple-300"
+        >
+          <FaArrowLeft
+            aria-hidden="true"
+            className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-1"
+          />
+          Voltar aos insights
+        </Link>
+        <ThemeToggle />
+      </nav>
+
+      <article>
+        <header className="relative mb-14 overflow-hidden rounded-3xl border border-slate-200/70 bg-white/55 px-5 py-10 dark:border-slate-700/70 dark:bg-slate-900/45 sm:px-8 sm:py-14 lg:px-12">
+          <div className="relative z-10 max-w-3xl animate-fade-in-up">
+            <p className="font-mono text-xs font-semibold uppercase tracking-[0.18em] text-purple-700 dark:text-purple-300">
+              {insight.category}
+            </p>
+            <h1 className="mt-5 text-4xl font-black leading-tight tracking-tight text-slate-950 dark:text-white sm:text-5xl lg:text-6xl">
+              {insight.title}
+            </h1>
+            <p className="mt-6 max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-300 sm:text-lg">
+              {insight.description}
+            </p>
+            <div className="mt-7 flex flex-wrap items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
+              <span>Por Anderson Dapper</span>
+              <span aria-hidden="true">·</span>
+              <time dateTime={insight.publishedAt}>{insight.publishedLabel}</time>
+              <span aria-hidden="true">·</span>
+              <span className="inline-flex items-center gap-1.5">
+                <FaClock aria-hidden="true" className="h-3 w-3" />
+                {insight.readTime}
+              </span>
+            </div>
+            <div className="mt-6 flex flex-wrap gap-2">
+              {insight.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full border border-slate-200/80 bg-white/75 px-3 py-1.5 text-xs font-medium text-slate-700 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div
+            aria-hidden="true"
+            className="absolute -right-16 -top-20 h-56 w-56 rounded-full bg-gradient-to-br from-purple-400/20 to-blue-500/5 blur-3xl"
+          />
+          <div
+            aria-hidden="true"
+            className="absolute -bottom-24 right-1/4 h-52 w-52 rounded-full bg-gradient-to-br from-cyan-500/15 to-transparent blur-3xl"
+          />
+        </header>
+
+        <div className="mx-auto max-w-3xl">
+          <aside className="mb-12 rounded-2xl border border-purple-200/70 bg-purple-50/65 p-5 dark:border-purple-900/60 dark:bg-purple-950/20 sm:p-7">
+            <p className="mb-2 font-mono text-xs font-semibold uppercase tracking-[0.16em] text-purple-700 dark:text-purple-300">
+              Em uma frase
+            </p>
+            <p className="text-lg font-semibold leading-relaxed text-slate-900 dark:text-slate-100 sm:text-xl">
+              {insight.thesis}
+            </p>
+          </aside>
+
+          <div className="mb-14 space-y-5 text-base leading-8 text-slate-700 dark:text-slate-300 sm:text-lg">
+            {insight.introduction.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </div>
+
+          <div className="space-y-14">
+            {insight.sections.map((section, index) => (
+              <section key={section.title} aria-labelledby={`insight-section-${index}`}>
+                <p className="mb-3 font-mono text-xs font-semibold uppercase tracking-[0.16em] text-cyan-700 dark:text-cyan-300">
+                  {section.eyebrow}
+                </p>
+                <h2
+                  id={`insight-section-${index}`}
+                  className="text-2xl font-bold leading-tight text-slate-950 dark:text-white sm:text-3xl"
+                >
+                  {section.title}
+                </h2>
+                <div className="mt-5 space-y-5 text-base leading-8 text-slate-700 dark:text-slate-300 sm:text-lg">
+                  {section.paragraphs.map((paragraph) => (
+                    <p key={paragraph}>{paragraph}</p>
+                  ))}
+                </div>
+
+                {section.points && (
+                  <ul className="mt-6 grid gap-3">
+                    {section.points.map((point) => (
+                      <li
+                        key={point}
+                        className="flex gap-3 rounded-xl border border-slate-200/70 bg-white/55 p-4 text-sm leading-relaxed text-slate-700 dark:border-slate-700/70 dark:bg-slate-800/55 dark:text-slate-300"
+                      >
+                        <FaCheckCircle
+                          aria-hidden="true"
+                          className="mt-0.5 h-4 w-4 shrink-0 text-cyan-600 dark:text-cyan-300"
+                        />
+                        {point}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {section.takeaway && (
+                  <p className="mt-6 border-l-2 border-purple-400 pl-4 text-sm font-medium leading-relaxed text-slate-700 dark:border-purple-500 dark:text-slate-300 sm:text-base">
+                    {section.takeaway}
+                  </p>
+                )}
+              </section>
+            ))}
+          </div>
+
+          <section className="my-14" aria-labelledby="checklist-title">
+            <SectionHeading
+              id="checklist-title"
+              eyebrow="Antes de avançar"
+              title="Checklist de uma migração verificável"
+              className="mb-7"
+            />
+            <ul className="grid gap-3">
+              {insight.checklist.map((item) => (
+                <li
+                  key={item}
+                  className="flex gap-3 rounded-xl border border-cyan-200/60 bg-cyan-50/60 p-4 text-sm leading-relaxed text-slate-700 dark:border-cyan-900/50 dark:bg-cyan-950/20 dark:text-slate-300"
+                >
+                  <FaCheckCircle
+                    aria-hidden="true"
+                    className="mt-0.5 h-4 w-4 shrink-0 text-cyan-600 dark:text-cyan-300"
+                  />
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="mb-14" aria-labelledby="conclusion-title">
+            <SectionHeading
+              id="conclusion-title"
+              eyebrow="Conclusão"
+              title="Evoluir sem apagar"
+              className="mb-7"
+            />
+            <div className="space-y-5 text-base leading-8 text-slate-700 dark:text-slate-300 sm:text-lg">
+              {insight.conclusion.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+          </section>
+
+          <aside className="rounded-2xl border border-slate-200/70 bg-gradient-to-br from-slate-50 via-purple-50 to-cyan-50 p-6 dark:border-slate-700/70 dark:from-slate-900 dark:via-purple-950/30 dark:to-cyan-950/30 sm:p-8">
+            <p className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-purple-700 dark:text-purple-300">
+              Aplicação em contexto real
+            </p>
+            <h2 className="mt-3 text-2xl font-bold text-slate-950 dark:text-white">
+              {insight.relatedCase.title}
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300 sm:text-base">
+              {insight.relatedCase.description}
+            </p>
+            <Link
+              href={`/cases/${insight.relatedCase.slug}`}
+              className="mt-6 inline-flex min-h-11 items-center gap-2 rounded-xl bg-gradient-to-r from-purple-500 to-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-purple-500/20 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
+            >
+              Explorar o case relacionado
+              <FaArrowRight aria-hidden="true" className="h-3.5 w-3.5" />
+            </Link>
+          </aside>
+        </div>
+      </article>
+    </div>
+  )
+}

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,0 +1,189 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { FaArrowLeft, FaArrowRight, FaBookOpen, FaClock } from 'react-icons/fa'
+import SectionHeading from '../../components/SectionHeading'
+import ThemeToggle from '../../components/ThemeToggle'
+import { publishedInsights } from '../../data/insights'
+
+const pageDescription =
+  'Artigos de Anderson Dapper sobre modernização de sistemas legados, arquitetura, integrações e entrega de software em contexto real.'
+
+export const metadata: Metadata = {
+  title: 'Insights',
+  description: pageDescription,
+  alternates: {
+    canonical: '/insights',
+  },
+  openGraph: {
+    type: 'website',
+    url: '/insights',
+    title: 'Insights de engenharia | Anderson Dapper',
+    description: pageDescription,
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Anderson Dapper - Software legado, APIs e Web',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Insights de engenharia | Anderson Dapper',
+    description: pageDescription,
+    images: ['/og-image.png'],
+  },
+}
+
+const themes = [
+  'Conhecimento preservado durante a modernização',
+  'Contratos explícitos para operações críticas',
+  'Evidência entre o commit e a produção',
+]
+
+export default function InsightsPage() {
+  return (
+    <div>
+      <nav
+        aria-label="Navegação da página"
+        className="mb-8 flex items-center justify-between gap-4 animate-fade-in"
+      >
+        <Link
+          href="/"
+          className="group inline-flex min-h-11 items-center gap-2 rounded-lg px-2 text-sm font-medium text-slate-500 transition-colors hover:text-cyan-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 dark:text-slate-400 dark:hover:text-cyan-300"
+        >
+          <FaArrowLeft
+            aria-hidden="true"
+            className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-1"
+          />
+          Voltar para a página inicial
+        </Link>
+        <ThemeToggle />
+      </nav>
+
+      <header className="relative mb-16 overflow-hidden rounded-3xl border border-slate-200/70 bg-white/55 px-5 py-10 dark:border-slate-700/70 dark:bg-slate-900/45 sm:px-8 sm:py-14 lg:px-12">
+        <div className="relative z-10 max-w-3xl animate-fade-in-up">
+          <div className="mb-5 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-purple-500 to-cyan-500 text-white shadow-lg shadow-purple-500/20">
+            <FaBookOpen aria-hidden="true" className="h-5 w-5" />
+          </div>
+          <p className="mb-4 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-purple-700 dark:text-purple-300">
+            Engenharia explicada a partir da prática
+          </p>
+          <h1 className="text-4xl font-black leading-tight tracking-tight text-slate-950 dark:text-white sm:text-5xl lg:text-6xl">
+            Ideias que sobreviveram ao código.
+          </h1>
+          <p className="mt-6 max-w-2xl text-base leading-relaxed text-slate-600 dark:text-slate-300 sm:text-lg">
+            Notas sobre decisões que continuam importantes quando o framework muda:
+            preservar regras, desenhar limites e provar que uma entrega funciona fora
+            do ambiente local.
+          </p>
+        </div>
+
+        <div
+          aria-hidden="true"
+          className="absolute -right-16 -top-20 h-56 w-56 rounded-full bg-gradient-to-br from-purple-400/20 to-cyan-500/5 blur-3xl"
+        />
+        <div
+          aria-hidden="true"
+          className="absolute -bottom-24 right-1/4 h-52 w-52 rounded-full bg-gradient-to-br from-cyan-500/15 to-transparent blur-3xl"
+        />
+      </header>
+
+      <section className="mb-16 sm:mb-20" aria-labelledby="insights-title">
+        <SectionHeading
+          id="insights-title"
+          eyebrow="Autoria técnica"
+          title="Textos publicados"
+          subtitle="Experiência transformada em princípios que podem ser discutidos, revisados e reutilizados."
+          className="mb-8"
+        />
+
+        <div className="grid gap-5">
+          {publishedInsights.map((insight) => (
+            <article
+              key={insight.slug}
+              className="group relative overflow-hidden rounded-2xl border border-slate-200/70 bg-white/60 p-5 shadow-sm transition-all hover:-translate-y-1 hover:shadow-xl dark:border-slate-700/70 dark:bg-slate-800/60 sm:p-7"
+            >
+              <div className="grid gap-7 lg:grid-cols-[1fr_0.58fr] lg:items-end">
+                <div>
+                  <p className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-purple-700 dark:text-purple-300">
+                    {insight.category}
+                  </p>
+                  <h2 className="mt-4 text-2xl font-bold leading-tight text-slate-950 dark:text-white sm:text-3xl">
+                    {insight.title}
+                  </h2>
+                  <p className="mt-4 text-base leading-relaxed text-slate-600 dark:text-slate-300">
+                    {insight.description}
+                  </p>
+                  <div className="mt-5 flex flex-wrap items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
+                    <span>{insight.publishedLabel}</span>
+                    <span aria-hidden="true">·</span>
+                    <span className="inline-flex items-center gap-1.5">
+                      <FaClock aria-hidden="true" className="h-3 w-3" />
+                      {insight.readTime}
+                    </span>
+                  </div>
+                </div>
+
+                <div>
+                  <div className="mb-5 flex flex-wrap gap-2">
+                    {insight.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="rounded-full border border-slate-200/80 bg-slate-50/80 px-3 py-1 text-xs font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                  <Link
+                    href={`/insights/${insight.slug}`}
+                    className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl border border-purple-300/80 bg-purple-50/80 px-4 py-2.5 text-sm font-semibold text-purple-800 transition-all hover:-translate-y-0.5 hover:border-purple-400 hover:bg-purple-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 dark:border-purple-800/70 dark:bg-purple-950/30 dark:text-purple-300 dark:hover:border-purple-600 dark:hover:bg-purple-950/50"
+                  >
+                    Ler insight
+                    <FaArrowRight
+                      aria-hidden="true"
+                      className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5"
+                    />
+                  </Link>
+                </div>
+              </div>
+
+              <div
+                aria-hidden="true"
+                className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-purple-500 via-blue-500 to-cyan-500"
+              />
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="themes-title"
+        className="rounded-2xl border border-slate-200/70 bg-gradient-to-br from-slate-50 via-purple-50 to-cyan-50 p-6 dark:border-slate-700/70 dark:from-slate-900 dark:via-purple-950/30 dark:to-cyan-950/30 sm:p-8"
+      >
+        <h2 id="themes-title" className="text-2xl font-bold text-slate-950 dark:text-white">
+          Linhas de pensamento
+        </h2>
+        <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-600 dark:text-slate-300 sm:text-base">
+          Os textos partem de problemas reais e procuram explicitar o raciocínio por
+          trás da implementação, sem depender de uma ferramenta específica.
+        </p>
+        <ul className="mt-6 grid gap-3 sm:grid-cols-3">
+          {themes.map((theme, index) => (
+            <li
+              key={theme}
+              className="rounded-xl border border-white/70 bg-white/65 p-4 text-sm leading-relaxed text-slate-700 dark:border-slate-700/70 dark:bg-slate-900/50 dark:text-slate-300"
+            >
+              <span className="mb-2 block font-mono text-xs font-bold text-purple-600 dark:text-purple-300">
+                0{index + 1}
+              </span>
+              {theme}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,11 +8,14 @@ import Footer from '../components/Footer'
 import SectionHeading from '../components/SectionHeading'
 import {
   FaArrowRight,
+  FaBookOpen,
+  FaClock,
   FaFileInvoice,
   FaLayerGroup,
   FaRocket,
 } from 'react-icons/fa'
 import { caseStudies, type CaseStudyIcon } from '../data/case-studies'
+import { publishedInsights } from '../data/insights'
 
 const caseStudyIcons: Record<CaseStudyIcon, typeof FaLayerGroup> = {
   layers: FaLayerGroup,
@@ -102,11 +105,84 @@ function FeaturedWork() {
   )
 }
 
+function FeaturedInsights() {
+  const insight = publishedInsights[0]
+
+  return (
+    <section className="mb-20" aria-labelledby="insights-title">
+      <SectionHeading
+        id="insights-title"
+        eyebrow="Experiência transformada em princípio"
+        title="Ideias que orientam meu trabalho"
+        subtitle="Textos sobre decisões técnicas que continuam relevantes quando a ferramenta muda."
+        className="mb-8"
+      />
+
+      <article className="group relative overflow-hidden rounded-2xl border border-slate-200/70 bg-white/65 p-5 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-slate-700/70 dark:bg-slate-800/65 sm:p-7">
+        <div className="grid gap-7 lg:grid-cols-[0.7fr_1.3fr] lg:items-center">
+          <div className="rounded-2xl border border-purple-200/60 bg-gradient-to-br from-purple-50 to-cyan-50 p-5 dark:border-purple-900/50 dark:from-purple-950/25 dark:to-cyan-950/25">
+            <div className="mb-5 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-purple-500 to-cyan-500 text-white shadow-lg shadow-purple-500/20">
+              <FaBookOpen aria-hidden="true" className="h-5 w-5" />
+            </div>
+            <p className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-purple-700 dark:text-purple-300">
+              {insight.category}
+            </p>
+            <div className="mt-4 flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+              <FaClock aria-hidden="true" className="h-3 w-3" />
+              {insight.readTime}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-2xl font-bold leading-tight text-slate-950 dark:text-white sm:text-3xl">
+              {insight.title}
+            </h3>
+            <p className="mt-4 text-base leading-relaxed text-slate-600 dark:text-slate-300">
+              {insight.description}
+            </p>
+            <div className="mt-5 flex flex-wrap gap-2">
+              {insight.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full border border-slate-200/80 bg-slate-50/80 px-3 py-1 text-xs font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href={`/insights/${insight.slug}`}
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-purple-500 to-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-purple-500/20 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
+              >
+                Ler insight
+                <FaArrowRight aria-hidden="true" className="h-3.5 w-3.5" />
+              </Link>
+              <Link
+                href="/insights"
+                className="inline-flex min-h-11 items-center justify-center rounded-xl border border-slate-300/80 bg-white/60 px-5 py-2.5 text-sm font-semibold text-slate-700 transition-all hover:-translate-y-0.5 hover:border-purple-400 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 dark:border-slate-600 dark:bg-slate-900/40 dark:text-slate-200 dark:hover:border-purple-500 dark:hover:bg-slate-900/70"
+              >
+                Ver todos os textos
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-purple-500 via-blue-500 to-cyan-500"
+        />
+      </article>
+    </section>
+  )
+}
+
 export default function HomePage() {
   return (
     <div>
       <Header />
       <FeaturedWork />
+      <FeaturedInsights />
       <About />
       <EasterEggWrapper />
       <Stack />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from 'next'
 import { publishedCaseStudies } from '../data/case-studies'
+import { publishedInsights } from '../data/insights'
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date()
@@ -26,6 +27,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...publishedCaseStudies.map(({ slug }) => ({
       url: `https://andersondapper.com.br/cases/${slug}`,
       lastModified,
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    })),
+    {
+      url: 'https://andersondapper.com.br/insights',
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.9,
+    },
+    ...publishedInsights.map(({ slug, publishedAt }) => ({
+      url: `https://andersondapper.com.br/insights/${slug}`,
+      lastModified: new Date(`${publishedAt}T12:00:00-03:00`),
       changeFrequency: 'monthly' as const,
       priority: 0.8,
     })),

--- a/src/data/insights.ts
+++ b/src/data/insights.ts
@@ -1,0 +1,144 @@
+interface InsightSection {
+  eyebrow: string
+  title: string
+  paragraphs: string[]
+  points?: string[]
+  takeaway?: string
+}
+
+interface RelatedCase {
+  slug: string
+  title: string
+  description: string
+}
+
+export interface Insight {
+  slug: string
+  title: string
+  description: string
+  category: string
+  publishedAt: string
+  publishedLabel: string
+  readTime: string
+  tags: string[]
+  thesis: string
+  introduction: string[]
+  sections: InsightSection[]
+  checklist: string[]
+  conclusion: string[]
+  relatedCase: RelatedCase
+}
+
+export const insights: Insight[] = [
+  {
+    slug: 'modernizar-legado-e-preservar-conhecimento',
+    title: 'Modernizar legado é preservar conhecimento, não copiar telas',
+    description:
+      'Um método para transformar comportamento acumulado em contratos explícitos e evoluir sistemas críticos sem apostar tudo em uma reescrita.',
+    category: 'Modernização de sistemas',
+    publishedAt: '2026-08-24',
+    publishedLabel: '24 de agosto de 2026',
+    readTime: '8 min de leitura',
+    tags: ['Legado', 'Arquitetura', 'Paridade', 'Entrega incremental'],
+    thesis:
+      'O objetivo de uma modernização não é reproduzir a aplicação antiga com outra tecnologia. É preservar o conhecimento que mantém a operação correta enquanto se criam limites melhores para a próxima década.',
+    introduction: [
+      'Modernização costuma ser apresentada como uma troca de tecnologia: sair de uma linguagem, adotar um framework, mover a interface para a Web. Em sistemas críticos, essa descrição é incompleta. O software existente também carrega decisões operacionais, exceções e regras que foram refinadas durante anos.',
+      'Quando esse conhecimento não está documentado, o comportamento do próprio sistema vira a referência mais confiável. A migração deixa de ser um exercício de transcrição e passa a ser um trabalho de descoberta, explicitação e prova.',
+    ],
+    sections: [
+      {
+        eyebrow: '01 · Contexto',
+        title: 'Código antigo também é documentação executável',
+        paragraphs: [
+          'Uma tela aparentemente simples pode combinar permissões, estados intermediários, arredondamentos, consultas, efeitos fiscais e atalhos operacionais. Cada detalhe isolado parece pequeno; juntos, eles formam o contrato real que os usuários conhecem.',
+          'Por isso, começar pela arquitetura futura sem mapear o comportamento atual cria uma lacuna perigosa. A equipe passa a discutir como o novo sistema deveria funcionar antes de compreender por que o atual funciona daquela maneira.',
+        ],
+        takeaway:
+          'Antes de substituir uma regra, torne explícito onde ela aparece, quais dados consome e quem depende do resultado.',
+      },
+      {
+        eyebrow: '02 · Baseline',
+        title: 'A primeira entrega é uma referência estável',
+        paragraphs: [
+          'Comparar uma solução nova com um legado que continua mudando é comparar dois alvos móveis. O primeiro passo é fixar uma versão de referência e registrar o recorte que será convertido: entradas, saídas, estados, permissões, consultas e integrações.',
+          'Essa baseline não precisa documentar o sistema inteiro. Ela precisa ser específica o suficiente para responder o que pertence à entrega atual e o que continua fora dela. O limite reduz ruído e impede que diferenças legítimas sejam confundidas com regressões.',
+        ],
+        points: [
+          'Versão exata do comportamento usado como referência.',
+          'Fluxos e estados que pertencem ao recorte.',
+          'Dados, integrações e efeitos colaterais envolvidos.',
+          'Exceções conhecidas e decisões ainda pendentes.',
+        ],
+      },
+      {
+        eyebrow: '03 · Recorte',
+        title: 'Migre fluxos completos, não camadas isoladas',
+        paragraphs: [
+          'Separar frontend, API e persistência em grandes projetos paralelos parece eficiente, mas adia a única pergunta que importa: o fluxo funciona de ponta a ponta? Uma interface sem regra real ou uma API sem uso concreto produz progresso difícil de validar.',
+          'Prefiro recortes verticais pequenos. Um fluxo atravessa interface, contrato, regra, dados e validação antes que o próximo comece. O resultado aparece mais cedo e cada entrega gera aprendizado aplicável à seguinte.',
+        ],
+        takeaway:
+          'Uma fatia menor e completa ensina mais do que várias camadas parcialmente prontas.',
+      },
+      {
+        eyebrow: '04 · Paridade',
+        title: 'Equivalência precisa de evidência independente',
+        paragraphs: [
+          'Paridade não significa copiar cada detalhe visual. Significa demonstrar que entradas relevantes produzem estados e resultados compatíveis, salvo quando uma mudança de comportamento foi decidida de forma explícita.',
+          'Testes ajudam, mas não substituem a referência. A comparação precisa combinar cenários automatizados, dados representativos e navegação real. Quando existe diferença, ela deve ser classificada como regressão, correção intencional ou decisão de produto — nunca tratada como impressão.',
+        ],
+        points: [
+          'Comparar resultados e transições, não apenas mensagens da interface.',
+          'Exercitar caminhos felizes, exceções e retomadas.',
+          'Registrar mudanças intencionais fora da conta de paridade.',
+          'Manter rastreabilidade entre regra antiga, contrato novo e prova.',
+        ],
+      },
+      {
+        eyebrow: '05 · Transição',
+        title: 'Coexistência é parte da arquitetura',
+        paragraphs: [
+          'Em sistemas que não podem parar, legado e nova solução convivem por algum tempo. Tratar essa convivência como improviso cria duplicidade de estado, caminhos ocultos e suporte confuso. Tratá-la como requisito permite definir claramente quem lê, quem grava e qual sistema responde por cada fluxo.',
+          'A substituição acontece quando o recorte novo acumula evidência suficiente, não quando o calendário pede uma grande virada. Isso preserva opções de recuperação e mantém o risco proporcional ao tamanho da entrega.',
+        ],
+        takeaway:
+          'A transição deve ter contratos tão claros quanto a arquitetura de destino.',
+      },
+      {
+        eyebrow: '06 · Produção',
+        title: 'O ciclo termina no comportamento publicado',
+        paragraphs: [
+          'Build, testes, deploy e operação saudável são provas diferentes. Um artefato pode compilar e não ser o que está atendendo usuários; um serviço pode iniciar e falhar na primeira integração real.',
+          'A validação final precisa conectar a revisão entregue à versão ativa, exercitar o fluxo no ambiente publicado e observar sinais coerentes de saúde. Essa disciplina fecha a distância entre código aprovado e resultado operacional.',
+        ],
+        takeaway:
+          'Pronto não é o momento em que o pipeline fica verde. É quando a versão correta funciona no ambiente correto com evidência suficiente.',
+      },
+    ],
+    checklist: [
+      'Existe uma versão exata do legado usada como referência?',
+      'O recorte inclui interface, regra, dados e validação?',
+      'Diferenças de comportamento foram classificadas explicitamente?',
+      'A convivência entre antigo e novo tem responsabilidades claras?',
+      'Cada prova — local, integração, deploy e runtime — está separada?',
+      'É possível relacionar o comportamento publicado à revisão entregue?',
+    ],
+    conclusion: [
+      'Modernizar bem exige respeito pelo sistema existente sem ficar preso às suas limitações. O legado fornece evidência sobre o negócio; a nova arquitetura transforma essa evidência em contratos mais claros, módulos mais independentes e entregas menores.',
+      'A tecnologia muda durante o caminho. O método permanece: delimitar, compreender, explicitar, migrar e provar. É isso que permite avançar sem apagar o conhecimento que tornou o software útil até aqui.',
+    ],
+    relatedCase: {
+      slug: 'modernizacao-sem-ruptura',
+      title: 'Modernização sem ruptura',
+      description:
+        'Veja como baseline, recortes verticais, paridade e validação aparecem em um contexto real e anonimizado.',
+    },
+  },
+]
+
+export const publishedInsights = insights
+
+export function getPublishedInsight(slug: string) {
+  return publishedInsights.find((insight) => insight.slug === slug)
+}


### PR DESCRIPTION
## O que muda

- cria o hub `/insights` para conteúdo de autoridade técnica;
- publica o primeiro artigo sobre modernização de legado e preservação de conhecimento;
- conecta o artigo ao case relacionado, sem abordagem comercial;
- adiciona uma seção de insights à página inicial;
- inclui metadata, JSON-LD e rotas no sitemap.

## Direção editorial

O site permanece uma presença pessoal voltada à autoridade técnica. Esta entrega não adiciona formulário, captura de leads ou funil de vendas.

## Validação

- `pnpm lint`
- `pnpm build`
- `pnpm exec tsc --noEmit --incremental false`
- hub e artigo renderizados com sucesso
- preview revisado e aprovado antes do commit
